### PR TITLE
jcat-self-test: Sign a simple string instead of /etc/machine-id

### DIFF
--- a/libjcat/jcat-self-test.c
+++ b/libjcat/jcat-self-test.c
@@ -481,6 +481,7 @@ static void
 jcat_pkcs7_engine_self_signed_func (void)
 {
 #ifdef ENABLE_PKCS7
+	static const char payload_str[] = "Hello, world!";
 	g_autofree gchar *str = NULL;
 	g_autoptr(JcatBlob) signature = NULL;
 	g_autoptr(JcatContext) context = jcat_context_new ();
@@ -504,8 +505,7 @@ jcat_pkcs7_engine_self_signed_func (void)
 	g_assert_no_error (error);
 	g_assert_nonnull (engine);
 
-	payload = jcat_get_contents_bytes ("/etc/machine-id", &error);
-	g_assert_no_error (error);
+	payload = g_bytes_new_static (payload_str, sizeof (payload_str));
 	g_assert_nonnull (payload);
 	signature = jcat_engine_self_sign (engine, payload, JCAT_SIGN_FLAG_ADD_TIMESTAMP, &error);
 	g_assert_no_error (error);


### PR DESCRIPTION
Containers and minimal autobuilder environments don't always have
a systemd machine ID, or any init system or related packages at all.
There's no real reason why we need the machine ID or a file here,
and jcat_get_contents_bytes() is exercised elsewhere, so we can sign a
string from memory instead.

Fixes: https://github.com/hughsie/libjcat/issues/22