### PR TITLE
lgtm: Install a newer Meson version using pip

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,10 @@
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - python3-pip
+        - python3-setuptools
+        - python3-wheel
+    after_prepare:
+      - python3 -m pip install --user "meson >= 0.52.0"
+      - export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
Loosely based on a version formerly used by systemd.

Might fix https://github.com/hughsie/libjcat/issues/21 or not, but I can't really test it without opening a PR :-)
