### PR TITLE
meson: Run generate-version-script.py using the same Python as meson itself

### DIFF
--- a/libjcat/meson.build
+++ b/libjcat/meson.build
@@ -129,6 +129,11 @@ if get_option('introspection')
     install : true,
   )
 
+  # Make sure generate-version-script.py is invoked by the same python as meson,
+  # as that one must already have both XML support and setuptools.
+  python = import('python')
+  python_interpreter = python.find_installation()
+
   # Verify the map file is correct -- note we can't actually use the generated
   # file for two reasons:
   #
@@ -141,6 +146,7 @@ if get_option('introspection')
     input: jcat_gir[0],
     output: 'jcat.map',
     command: [
+      python_interpreter,
       join_paths(meson.source_root(), 'contrib', 'generate-version-script.py'),
       'LIBJCAT',
       '@INPUT@',


### PR DESCRIPTION
By default, _i.e._ when executed directly, _generate-version-script.py_ uses /usr/bin/python3, whatever version that may be - which causes problems if the default python3 installation either is built without XML support or does not provide setuptools. Make sure the script is invoked using the same interpreter as meson itself, as that one is already guaranteed to provide both 'xml' and 'pkg_resources'.