### PR TITLE
Allow adding an item ID 'alias'

### DIFF
--- a/libjcat/jcat-item.c
+++ b/libjcat/jcat-item.c
@@ -13,6 +13,7 @@
 typedef struct {
 	gchar			*id;
 	GPtrArray		*blobs;
+	GPtrArray		*alias_ids;
 } JcatItemPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (JcatItem, jcat_item, G_TYPE_OBJECT)
@@ -25,6 +26,7 @@ jcat_item_finalize (GObject *obj)
 	JcatItemPrivate *priv = GET_PRIVATE (self);
 	g_free (priv->id);
 	g_ptr_array_unref (priv->blobs);
+	g_ptr_array_unref (priv->alias_ids);
 	G_OBJECT_CLASS (jcat_item_parent_class)->finalize (obj);
 }
 
@@ -40,6 +42,7 @@ jcat_item_init (JcatItem *self)
 {
 	JcatItemPrivate *priv = GET_PRIVATE (self);
 	priv->blobs = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
+	priv->alias_ids = g_ptr_array_new_with_free_func (g_free);
 }
 
 /* private */
@@ -49,6 +52,10 @@ jcat_item_add_string (JcatItem *self, guint idt, GString *str)
 	JcatItemPrivate *priv = GET_PRIVATE (self);
 	jcat_string_append_kv (str, idt, G_OBJECT_TYPE_NAME (self), NULL);
 	jcat_string_append_kv (str, idt + 1, "ID", priv->id);
+	for (guint i = 0; i < priv->alias_ids->len; i++) {
+		const gchar *alias_id = g_ptr_array_index (priv->alias_ids, i);
+		jcat_string_append_kv (str, idt + 1, "AliasId", alias_id);
+	}
 	for (guint i = 0; i < priv->blobs->len; i++) {
 		JcatBlob *blob = g_ptr_array_index (priv->blobs, i);
 		jcat_blob_add_string (blob, idt + 1, str);
@@ -115,6 +122,32 @@ jcat_item_import (JsonObject *obj, JcatImportFlags flags, GError **error)
 		jcat_item_add_blob (self, blob);
 	}
 
+	/* get alias_ids */
+	if (json_object_has_member (obj, "AliasIds")) {
+		JsonArray *array;
+		g_autoptr(GList) alias_ids = NULL;
+		array = json_object_get_array_member (obj, "AliasIds");
+		if (array == NULL) {
+			g_set_error_literal (error,
+					     G_IO_ERROR,
+					     G_IO_ERROR_INVALID_DATA,
+					     "failed to read AliasIds array");
+			return NULL;
+		}
+		alias_ids = json_array_get_elements (array);
+		for (GList *l = alias_ids; l != NULL; l = l->next) {
+			JsonNode *node = l->data;
+			if (!JSON_NODE_HOLDS_VALUE (node)) {
+				g_set_error_literal (error,
+						     G_IO_ERROR,
+						     G_IO_ERROR_INVALID_DATA,
+						     "failed to read AliasIds value");
+				return NULL;
+			}
+			jcat_item_add_alias_id (self, json_node_get_string (node));
+		}
+	}
+
 	/* success */
 	return g_steal_pointer (&self);
 }
@@ -127,6 +160,17 @@ jcat_item_export (JcatItem *self, JcatExportFlags flags, JsonBuilder *builder)
 	/* add metadata */
 	json_builder_set_member_name (builder, "Id");
 	json_builder_add_string_value (builder, priv->id);
+
+	/* add alias_ids */
+	if (priv->blobs->len > 0) {
+		json_builder_set_member_name (builder, "AliasIds");
+		json_builder_begin_array (builder);
+		for (guint i = 0; i < priv->alias_ids->len; i++) {
+			const gchar *id_tmp = g_ptr_array_index (priv->alias_ids, i);
+			json_builder_add_string_value (builder, id_tmp);
+		}
+		json_builder_end_array (builder);
+	}
 
 	/* add items */
 	if (priv->blobs->len > 0) {
@@ -236,6 +280,70 @@ jcat_item_get_id (JcatItem *self)
 	JcatItemPrivate *priv = GET_PRIVATE (self);
 	g_return_val_if_fail (JCAT_IS_ITEM (self), NULL);
 	return priv->id;
+}
+
+/**
+ * jcat_item_add_alias_id:
+ * @self: #JcatItem
+ * @id: An item ID alias, typically a file basename
+ *
+ * Adds an item alias ID. Alias IDs are matched when using functions such as
+ * jcat_file_get_item_by_id().
+ *
+ * Since: 0.1.1
+ **/
+void
+jcat_item_add_alias_id (JcatItem *self, const gchar *id)
+{
+	JcatItemPrivate *priv = GET_PRIVATE (self);
+	g_return_if_fail (JCAT_IS_ITEM (self));
+	for (guint i = 0; i < priv->alias_ids->len; i++) {
+		const gchar *id_tmp = g_ptr_array_index (priv->alias_ids, i);
+		if (g_strcmp0 (id, id_tmp) == 0)
+			return;
+	}
+	g_ptr_array_add (priv->alias_ids, g_strdup (id));
+}
+
+/**
+ * jcat_item_remove_alias_id:
+ * @self: #JcatItem
+ * @id: An item ID alias, typically a file basename
+ *
+ * Removes an item alias ID.
+ *
+ * Since: 0.1.1
+ **/
+void
+jcat_item_remove_alias_id (JcatItem *self, const gchar *id)
+{
+	JcatItemPrivate *priv = GET_PRIVATE (self);
+	g_return_if_fail (JCAT_IS_ITEM (self));
+	for (guint i = 0; i < priv->alias_ids->len; i++) {
+		const gchar *id_tmp = g_ptr_array_index (priv->alias_ids, i);
+		if (g_strcmp0 (id, id_tmp) == 0) {
+			g_ptr_array_remove (priv->alias_ids, id_tmp);
+			return;
+		}
+	}
+}
+
+/**
+ * jcat_item_get_alias_ids:
+ * @self: #JcatItem
+ *
+ * Gets the list of alias IDs.
+ *
+ * Returns: (transfer container) (element-type utf8): array
+ *
+ * Since: 0.1.1
+ **/
+GPtrArray *
+jcat_item_get_alias_ids (JcatItem *self)
+{
+	JcatItemPrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (JCAT_IS_ITEM (self), NULL);
+	return g_ptr_array_ref (priv->alias_ids);
 }
 
 /**

--- a/libjcat/jcat-item.h
+++ b/libjcat/jcat-item.h
@@ -28,3 +28,8 @@ GPtrArray	*jcat_item_get_blobs_by_kind		(JcatItem	*self,
 void		 jcat_item_add_blob			(JcatItem	*self,
 							 JcatBlob	*blob);
 const gchar	*jcat_item_get_id			(JcatItem	*self);
+void		 jcat_item_add_alias_id			(JcatItem	*self,
+							 const gchar	*id);
+void		 jcat_item_remove_alias_id		(JcatItem	*self,
+							 const gchar	*id);
+GPtrArray	*jcat_item_get_alias_ids		(JcatItem	*self);

--- a/libjcat/jcat-self-test.c
+++ b/libjcat/jcat-self-test.c
@@ -61,10 +61,14 @@ jcat_item_func (void)
 	g_autoptr(JcatItem) item = NULL;
 	const gchar *str_perfect =
 		"JcatItem:\n"
-		"  ID:                    filename.bin\n";
+		"  ID:                    filename.bin\n"
+		"  AliasId:               foo.bin\n";
 
 	/* sanity check */
 	item = jcat_item_new ("filename.bin");
+	jcat_item_add_alias_id (item, "foo.bin");
+	jcat_item_add_alias_id (item, "bar.bin");
+	jcat_item_remove_alias_id (item, "bar.bin");
 	g_assert_cmpstr (jcat_item_get_id (item), ==, "filename.bin");
 
 	/* to string */
@@ -103,6 +107,9 @@ jcat_file_func (void)
 		"  \"Items\" : [\n"
 		"    {\n"
 		"      \"Id\" : \"firmware.bin\",\n"
+		"      \"AliasIds\" : [\n"
+		"        \"foo.bin\"\n"
+		"      ],\n"
 		"      \"Blobs\" : [\n"
 		"        {\n"
 		"          \"Kind\" : 2,\n"
@@ -142,6 +149,7 @@ jcat_file_func (void)
 	jcat_item_add_blob (item, blob1);
 	jcat_item_add_blob (item, blob2);
 	jcat_item_add_blob (item, blob2);
+	jcat_item_add_alias_id (item, "foo.bin");
 	blobs1 = jcat_item_get_blobs (item);
 	g_assert_cmpint (blobs1->len, ==, 2);
 	blobs2 = jcat_item_get_blobs_by_kind (item, JCAT_BLOB_KIND_GPG);

--- a/libjcat/jcat.map
+++ b/libjcat/jcat.map
@@ -59,3 +59,11 @@ LIBJCAT_0.1.0 {
     jcat_result_to_string;
   local: *;
 };
+
+LIBJCAT_0.1.1 {
+  global:
+    jcat_item_add_alias_id;
+    jcat_item_get_alias_ids;
+    jcat_item_remove_alias_id;
+  local: *;
+} LIBJCAT_0.1.0;


### PR DESCRIPTION
This allows us to still validate when we have to rename the file we want to
validate. Typically this would be used when the client software is expecting
an ID of `payload.xml` but we sign something called `payload-{date}.xml`.