### PR TITLE
build: Check for Python modules explicitly

### DIFF
--- a/libjcat/meson.build
+++ b/libjcat/meson.build
@@ -131,10 +131,13 @@ if get_option('introspection')
     install : true,
   )
 
-  # Make sure generate-version-script.py is invoked by the same python as meson,
-  # as that one must already have both XML support and setuptools.
   python = import('python')
-  python_interpreter = python.find_installation()
+  python_interpreter = python.find_installation('python3',
+    modules: [
+      'xml.etree.ElementTree',
+      'pkg_resources',
+    ],
+  )
 
   # Verify the map file is correct -- note we can't actually use the generated
   # file for two reasons:


### PR DESCRIPTION
It is not true that Meson's Python will always have setuptools as that is only required during build.
See https://discuss.python.org/t/build-system-and-undeclared-dependency-on-it-during-runtime/2455

To be sure, let's check for the required modules explicitly.

cc @mkszuba 