### PR TITLE
Export the JcatBlobKind and JcatBlobMethod on the result

### DIFF
--- a/libjcat/jcat-blob.h
+++ b/libjcat/jcat-blob.h
@@ -33,6 +33,22 @@ typedef enum {
 } JcatBlobKind;
 
 /**
+ * JcatBlobMethod:
+ * @JCAT_BLOB_METHOD_UNKNOWN:		Unknown
+ * @JCAT_BLOB_METHOD_CHECKSUM:		Checksum
+ * @JCAT_BLOB_METHOD_SIGNATURE:		Signature
+ *
+ * The blob verification method.
+ **/
+typedef enum {
+	JCAT_BLOB_METHOD_UNKNOWN,
+	JCAT_BLOB_METHOD_CHECKSUM,
+	JCAT_BLOB_METHOD_SIGNATURE,
+	/*< private >*/
+	JCAT_BLOB_METHOD_LAST
+} JcatBlobMethod;
+
+/**
  * JcatBlobFlags:
  * @JCAT_BLOB_FLAG_NONE:		Generic binary data
  * @JCAT_BLOB_FLAG_IS_UTF8:		ASCII text

--- a/libjcat/jcat-context.c
+++ b/libjcat/jcat-context.c
@@ -235,7 +235,7 @@ jcat_context_verify_blob (JcatContext *self,
  * @error: #GError, or %NULL
  *
  * Verifies a #JcatItem using the public keys added to the context. All
- * `verify_kind=CHECKSUM` engines (e.g. SHA256) must verify correctly,
+ * `verify=CHECKSUM` engines (e.g. SHA256) must verify correctly,
  * but only one non-checksum signature has to verify.
  *
  * Returns: (transfer container) (element-type JcatResult): array of #JcatResult, or %NULL for failed
@@ -267,7 +267,7 @@ jcat_context_verify_item (JcatContext *self,
 		return NULL;
 	}
 
-	/* all verify_kind engines must verify */
+	/* all checksum engines must verify */
 	for (guint i = 0; i < blobs->len; i++) {
 		JcatBlob *blob = g_ptr_array_index (blobs, i);
 		g_autoptr(JcatEngine) engine = NULL;
@@ -277,7 +277,7 @@ jcat_context_verify_item (JcatContext *self,
 		engine = jcat_context_get_engine (self, jcat_blob_get_kind (blob), error);
 		if (engine == NULL)
 			return NULL;
-		if (jcat_engine_get_verify_kind (engine) != JCAT_ENGINE_VERIFY_KIND_CHECKSUM)
+		if (jcat_engine_get_method (engine) != JCAT_BLOB_METHOD_CHECKSUM)
 			continue;
 		result = jcat_engine_self_verify (engine, data, jcat_blob_get_data (blob), flags, error);
 		if (result == NULL) {
@@ -294,7 +294,7 @@ jcat_context_verify_item (JcatContext *self,
 		return NULL;
 	}
 
-	/* we only have to have one non-verify_kind engine to verify */
+	/* we only have to have one non-checksum method to verify */
 	for (guint i = 0; i < blobs->len; i++) {
 		JcatBlob *blob = g_ptr_array_index (blobs, i);
 		g_autofree gchar *result_str = NULL;
@@ -305,7 +305,7 @@ jcat_context_verify_item (JcatContext *self,
 		engine = jcat_context_get_engine (self, jcat_blob_get_kind (blob), error);
 		if (engine == NULL)
 			return NULL;
-		if (jcat_engine_get_verify_kind (engine) != JCAT_ENGINE_VERIFY_KIND_SIGNATURE)
+		if (jcat_engine_get_method (engine) != JCAT_BLOB_METHOD_SIGNATURE)
 			continue;
 		result = jcat_engine_pubkey_verify (engine, data, jcat_blob_get_data (blob), flags, &error_local);
 		if (result == NULL) {

--- a/libjcat/jcat-engine-private.h
+++ b/libjcat/jcat-engine-private.h
@@ -8,15 +8,6 @@
 
 #include "jcat-engine.h"
 
-typedef enum {
-	JCAT_ENGINE_VERIFY_KIND_UNKNOWN,
-	JCAT_ENGINE_VERIFY_KIND_CHECKSUM,
-	JCAT_ENGINE_VERIFY_KIND_SIGNATURE,
-	JCAT_ENGINE_VERIFY_KIND_LAST
-} JcatEngineVerifyKind;
-
-JcatBlobKind	 jcat_engine_get_kind			(JcatEngine	*self);
-JcatEngineVerifyKind jcat_engine_get_verify_kind	(JcatEngine	*self);
 const gchar	*jcat_engine_get_keyring_path		(JcatEngine	*self);
 void		 jcat_engine_add_string			(JcatEngine	*self,
 							 guint		 idt,

--- a/libjcat/jcat-engine.c
+++ b/libjcat/jcat-engine.c
@@ -13,7 +13,7 @@
 typedef struct {
 	JcatContext		*context;		/* weak */
 	JcatBlobKind		 kind;
-	JcatEngineVerifyKind	 verify_kind;
+	JcatBlobMethod		 method;
 	gboolean		 done_setup;
 } JcatEnginePrivate;
 
@@ -24,16 +24,16 @@ enum {
 	PROP_0,
 	PROP_CONTEXT,
 	PROP_KIND,
-	PROP_VERIFY_KIND,
+	PROP_METHOD,
 	PROP_LAST
 };
 
 static const gchar *
-jcat_engine_verify_kind_to_string (JcatEngineVerifyKind verify_kind)
+jcat_engine_method_to_string (JcatBlobMethod method)
 {
-	if (verify_kind == JCAT_ENGINE_VERIFY_KIND_CHECKSUM)
+	if (method == JCAT_BLOB_METHOD_CHECKSUM)
 		return "checksum";
-	if (verify_kind == JCAT_ENGINE_VERIFY_KIND_SIGNATURE)
+	if (method == JCAT_BLOB_METHOD_SIGNATURE)
 		return "signature";
 	return NULL;
 }
@@ -47,7 +47,7 @@ jcat_engine_add_string (JcatEngine *self, guint idt, GString *str)
 	jcat_string_append_kv (str, idt + 1, "Kind",
 			       jcat_blob_kind_to_string (priv->kind));
 	jcat_string_append_kv (str, idt + 1, "VerifyKind",
-			       jcat_engine_verify_kind_to_string (priv->verify_kind));
+			       jcat_engine_method_to_string (priv->method));
 }
 
 /* private */
@@ -238,6 +238,16 @@ jcat_engine_self_sign (JcatEngine *self,
 	return klass->self_sign (self, blob, flags, error);
 }
 
+/**
+ * jcat_engine_get_kind:
+ * @self: #JcatEngine
+ *
+ * Gets the blob kind.
+ *
+ * Returns: #JcatBlobKind, e.g. %JCAT_BLOB_KIND_SHA256
+ *
+ * Since: 0.1.3
+ **/
 JcatBlobKind
 jcat_engine_get_kind (JcatEngine *self)
 {
@@ -245,11 +255,21 @@ jcat_engine_get_kind (JcatEngine *self)
 	return priv->kind;
 }
 
-JcatEngineVerifyKind
-jcat_engine_get_verify_kind (JcatEngine *self)
+/**
+ * jcat_engine_get_method:
+ * @self: #JcatEngine
+ *
+ * Gets the verification method.
+ *
+ * Returns: #JcatBlobMethod, e.g. %JCAT_BLOB_METHOD_SIGNATURE
+ *
+ * Since: 0.1.3
+ **/
+JcatBlobMethod
+jcat_engine_get_method (JcatEngine *self)
 {
 	JcatEnginePrivate *priv = GET_PRIVATE (self);
-	return priv->verify_kind;
+	return priv->method;
 }
 
 const gchar *
@@ -280,8 +300,8 @@ jcat_engine_get_property (GObject *object, guint prop_id,
 	case PROP_KIND:
 		g_value_set_uint (value, priv->kind);
 		break;
-	case PROP_VERIFY_KIND:
-		g_value_set_uint (value, priv->verify_kind);
+	case PROP_METHOD:
+		g_value_set_uint (value, priv->method);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -303,8 +323,8 @@ jcat_engine_set_property (GObject *object, guint prop_id,
 	case PROP_KIND:
 		priv->kind = g_value_get_uint (value);
 		break;
-	case PROP_VERIFY_KIND:
-		priv->verify_kind = g_value_get_uint (value);
+	case PROP_METHOD:
+		priv->method = g_value_get_uint (value);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -335,14 +355,14 @@ jcat_engine_class_init (JcatEngineClass *klass)
 				   G_PARAM_STATIC_NAME);
 	g_object_class_install_property (object_class, PROP_KIND, pspec);
 
-	pspec = g_param_spec_uint ("verify-kind", NULL, NULL,
-				   JCAT_ENGINE_VERIFY_KIND_UNKNOWN,
-				   JCAT_ENGINE_VERIFY_KIND_LAST,
-				   JCAT_ENGINE_VERIFY_KIND_UNKNOWN,
+	pspec = g_param_spec_uint ("method", NULL, NULL,
+				   JCAT_BLOB_METHOD_UNKNOWN,
+				   JCAT_BLOB_METHOD_LAST,
+				   JCAT_BLOB_METHOD_UNKNOWN,
 				   G_PARAM_READWRITE |
 				   G_PARAM_CONSTRUCT_ONLY |
 				   G_PARAM_STATIC_NAME);
-	g_object_class_install_property (object_class, PROP_VERIFY_KIND, pspec);
+	g_object_class_install_property (object_class, PROP_METHOD, pspec);
 	object_class->finalize = jcat_engine_finalize;
 }
 

--- a/libjcat/jcat-engine.h
+++ b/libjcat/jcat-engine.h
@@ -47,6 +47,8 @@ struct _JcatEngineClass
 	gpointer		 padding[9];
 };
 
+JcatBlobKind	 jcat_engine_get_kind			(JcatEngine	*self);
+JcatBlobMethod	 jcat_engine_get_method			(JcatEngine	*self);
 JcatResult	*jcat_engine_pubkey_verify		(JcatEngine	*self,
 							 GBytes		*blob,
 							 GBytes		*blob_signature,

--- a/libjcat/jcat-gpg-engine.c
+++ b/libjcat/jcat-gpg-engine.c
@@ -326,6 +326,6 @@ jcat_gpg_engine_new (JcatContext *context)
 	return JCAT_ENGINE (g_object_new (JCAT_TYPE_GPG_ENGINE,
 					  "context", context,
 					  "kind", JCAT_BLOB_KIND_GPG,
-					  "verify-kind", JCAT_ENGINE_VERIFY_KIND_SIGNATURE,
+					  "method", JCAT_BLOB_METHOD_SIGNATURE,
 					  NULL));
 }

--- a/libjcat/jcat-pkcs7-engine.c
+++ b/libjcat/jcat-pkcs7-engine.c
@@ -464,6 +464,6 @@ jcat_pkcs7_engine_new (JcatContext *context)
 	return JCAT_ENGINE (g_object_new (JCAT_TYPE_PKCS7_ENGINE,
 					  "context", context,
 					  "kind", JCAT_BLOB_KIND_PKCS7,
-					  "verify-kind", JCAT_ENGINE_VERIFY_KIND_SIGNATURE,
+					  "method", JCAT_BLOB_METHOD_SIGNATURE,
 					  NULL));
 }

--- a/libjcat/jcat-result.c
+++ b/libjcat/jcat-result.c
@@ -81,6 +81,43 @@ jcat_result_get_authority (JcatResult *self)
 	return self->authority;
 }
 
+
+/**
+ * jcat_result_get_kind:
+ * @self: #JcatResult
+ *
+ * Gets the blob kind.
+ *
+ * Returns: #JcatBlobKind, e.g. %JCAT_BLOB_KIND_SHA256
+ *
+ * Since: 0.1.3
+ **/
+JcatBlobKind
+jcat_result_get_kind (JcatResult *self)
+{
+	if (self->engine == NULL)
+		return JCAT_BLOB_KIND_UNKNOWN;
+	return jcat_engine_get_kind (self->engine);
+}
+
+/**
+ * jcat_result_get_method:
+ * @self: #JcatResult
+ *
+ * Gets the verification kind.
+ *
+ * Returns: #JcatBlobMethod, e.g. %JCAT_BLOB_METHOD_SIGNATURE
+ *
+ * Since: 0.1.3
+ **/
+JcatBlobMethod
+jcat_result_get_method (JcatResult *self)
+{
+	if (self->engine == NULL)
+		return JCAT_BLOB_METHOD_UNKNOWN;
+	return jcat_engine_get_method (self->engine);
+}
+
 /* private */
 void
 jcat_result_add_string (JcatResult *self, guint idt, GString *str)

--- a/libjcat/jcat-result.h
+++ b/libjcat/jcat-result.h
@@ -12,6 +12,8 @@
 
 G_DECLARE_FINAL_TYPE (JcatResult, jcat_result, JCAT, RESULT, GObject)
 
-gchar		*jcat_result_to_string 		(JcatResult	*self);
-gint64		 jcat_result_get_timestamp	(JcatResult	*self);
-const gchar	*jcat_result_get_authority	(JcatResult	*self);
+gchar		*jcat_result_to_string 			(JcatResult	*self);
+gint64		 jcat_result_get_timestamp		(JcatResult	*self);
+const gchar	*jcat_result_get_authority		(JcatResult	*self);
+JcatBlobKind	 jcat_result_get_kind			(JcatResult	*self);
+JcatBlobMethod	 jcat_result_get_method			(JcatResult	*self);

--- a/libjcat/jcat-self-test.c
+++ b/libjcat/jcat-self-test.c
@@ -221,7 +221,7 @@ jcat_sha1_engine_func (void)
 	g_assert_no_error (error);
 	g_assert_nonnull (engine);
 	g_assert_cmpint (jcat_engine_get_kind (engine), ==, JCAT_BLOB_KIND_SHA1);
-	g_assert_cmpint (jcat_engine_get_verify_kind (engine), ==, JCAT_ENGINE_VERIFY_KIND_CHECKSUM);
+	g_assert_cmpint (jcat_engine_get_method (engine), ==, JCAT_BLOB_METHOD_CHECKSUM);
 
 	/* verify checksum */
 	fn_pass = g_test_build_filename (G_TEST_DIST, "colorhug", "firmware.bin", NULL);
@@ -279,7 +279,7 @@ jcat_sha256_engine_func (void)
 	g_assert_no_error (error);
 	g_assert_nonnull (engine);
 	g_assert_cmpint (jcat_engine_get_kind (engine), ==, JCAT_BLOB_KIND_SHA256);
-	g_assert_cmpint (jcat_engine_get_verify_kind (engine), ==, JCAT_ENGINE_VERIFY_KIND_CHECKSUM);
+	g_assert_cmpint (jcat_engine_get_method (engine), ==, JCAT_BLOB_METHOD_CHECKSUM);
 
 	/* verify checksum */
 	fn_pass = g_test_build_filename (G_TEST_DIST, "colorhug", "firmware.bin", NULL);
@@ -356,7 +356,7 @@ jcat_gpg_engine_func (void)
 	g_assert_no_error (error);
 	g_assert_nonnull (engine);
 	g_assert_cmpint (jcat_engine_get_kind (engine), ==, JCAT_BLOB_KIND_GPG);
-	g_assert_cmpint (jcat_engine_get_verify_kind (engine), ==, JCAT_ENGINE_VERIFY_KIND_SIGNATURE);
+	g_assert_cmpint (jcat_engine_get_method (engine), ==, JCAT_BLOB_METHOD_SIGNATURE);
 
 	/* to string */
 	str = jcat_engine_to_string (engine);
@@ -428,7 +428,7 @@ jcat_gpg_engine_msg_func (void)
 	g_assert_no_error (error);
 	g_assert_nonnull (engine);
 	g_assert_cmpint (jcat_engine_get_kind (engine), ==, JCAT_BLOB_KIND_GPG);
-	g_assert_cmpint (jcat_engine_get_verify_kind (engine), ==, JCAT_ENGINE_VERIFY_KIND_SIGNATURE);
+	g_assert_cmpint (jcat_engine_get_method (engine), ==, JCAT_BLOB_METHOD_SIGNATURE);
 
 	/* verify with GnuPG, which should fail as the signature is not a
 	 * detached signature at all, but gnupg stabs us in the back by returning
@@ -476,7 +476,7 @@ jcat_pkcs7_engine_func (void)
 	g_assert_no_error (error);
 	g_assert_nonnull (engine);
 	g_assert_cmpint (jcat_engine_get_kind (engine), ==, JCAT_BLOB_KIND_PKCS7);
-	g_assert_cmpint (jcat_engine_get_verify_kind (engine), ==, JCAT_ENGINE_VERIFY_KIND_SIGNATURE);
+	g_assert_cmpint (jcat_engine_get_method (engine), ==, JCAT_BLOB_METHOD_SIGNATURE);
 
 	/* verify with a signature from the old LVFS */
 	fn_pass = g_test_build_filename (G_TEST_DIST, "colorhug", "firmware.bin", NULL);

--- a/libjcat/jcat-sha1-engine.c
+++ b/libjcat/jcat-sha1-engine.c
@@ -80,6 +80,6 @@ jcat_sha1_engine_new (JcatContext *context)
 	return JCAT_ENGINE (g_object_new (JCAT_TYPE_SHA1_ENGINE,
 					  "context", context,
 					  "kind", JCAT_BLOB_KIND_SHA1,
-					  "verify-kind", JCAT_ENGINE_VERIFY_KIND_CHECKSUM,
+					  "method", JCAT_BLOB_METHOD_CHECKSUM,
 					  NULL));
 }

--- a/libjcat/jcat-sha256-engine.c
+++ b/libjcat/jcat-sha256-engine.c
@@ -80,6 +80,6 @@ jcat_sha256_engine_new (JcatContext *context)
 	return JCAT_ENGINE (g_object_new (JCAT_TYPE_SHA256_ENGINE,
 					  "context", context,
 					  "kind", JCAT_BLOB_KIND_SHA256,
-					  "verify-kind", JCAT_ENGINE_VERIFY_KIND_CHECKSUM,
+					  "method", JCAT_BLOB_METHOD_CHECKSUM,
 					  NULL));
 }

--- a/libjcat/jcat.map
+++ b/libjcat/jcat.map
@@ -67,3 +67,12 @@ LIBJCAT_0.1.1 {
     jcat_item_remove_alias_id;
   local: *;
 } LIBJCAT_0.1.0;
+
+LIBJCAT_0.1.3 {
+  global:
+    jcat_engine_get_kind;
+    jcat_engine_get_method;
+    jcat_result_get_kind;
+    jcat_result_get_method;
+  local: *;
+} LIBJCAT_0.1.1;


### PR DESCRIPTION
We need this information to correctly collect the timestamp from the correct
result after jcat_context_verify_item() in fwupd.