### PR TITLE
trivial: bump minimum meson.build version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libjcat', 'c',
   version : '0.1.4',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.49.2',
+  meson_version : '>=0.51.0',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 


### PR DESCRIPTION
Remove the two warnings about new features from 0.50 and 0.51.