### PR TITLE
Do not use help2man to build manual pages

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,7 +20,6 @@ jobs:
         gnutls-bin \
         gobject-introspection \
         gtk-doc-tools \
-        help2man \
         libgirepository1.0-dev \
         libglib2.0-dev \
         libglib2.0-dev-bin \

--- a/contrib/ci/Dockerfile-debian
+++ b/contrib/ci/Dockerfile-debian
@@ -7,7 +7,6 @@ RUN apt-get install -yq --no-install-recommends \
 	gnutls-dev \
 	gobject-introspection \
 	gtk-doc-tools \
-	help2man \
 	libgirepository1.0-dev \
 	libglib2.0-dev \
 	libglib2.0-dev-bin \

--- a/contrib/ci/Dockerfile-fedora
+++ b/contrib/ci/Dockerfile-fedora
@@ -11,7 +11,6 @@ RUN dnf -y install \
 	gobject-introspection-devel \
 	gpgme-devel \
 	gtk-doc \
-	help2man \
 	json-glib-devel \
 	meson \
 	redhat-rpm-config \

--- a/contrib/libjcat.spec.in
+++ b/contrib/libjcat.spec.in
@@ -20,7 +20,6 @@ BuildRequires: gnutls-devel
 BuildRequires: gnutls-utils
 BuildRequires: gpgme-devel
 BuildRequires: vala
-BuildRequires: help2man
 
 Requires: glib2%{?_isa} >= %{glib2_version}
 

--- a/libjcat/jcat-tool.1
+++ b/libjcat/jcat-tool.1
@@ -1,0 +1,20 @@
+.\" Report problems in https://github.com/hughsie/libjcat
+.TH man 8 "11 April 2021" @PACKAGE_VERSION@ "jcat-tool man page"
+.SH NAME
+jcat-tool \- standalone detached signature utility
+.SH SYNOPSIS
+jcat-tool [CMD]
+.SH DESCRIPTION
+.PP
+This manual page documents briefly the \fBjcat-tool\fR command.
+.PP
+\fBjcat-tool\fR allows a user to read, create and modify \fB.jcat\fR files.
+.SH OPTIONS
+The jcat-tool command takes various options depending on the action.
+Run \fBjcat-tool --help\fR for the full list.
+.SH SEE ALSO
+certtool(1)
+.SH BUGS
+No known bugs.
+.SH AUTHOR
+Richard Hughes (richard@hughsie.com)

--- a/libjcat/meson.build
+++ b/libjcat/meson.build
@@ -195,20 +195,12 @@ jcat_tool = executable(
 )
 
 if get_option('man')
-  help2man = find_program('help2man')
-  custom_target('jcat-tool-man',
-    input : jcat_tool,
+  configure_file(
+    input : 'jcat-tool.1',
     output : 'jcat-tool.1',
-    command : [
-      help2man, '@INPUT@',
-      '--no-info',
-      '--output', '@OUTPUT@',
-      '--name', 'Standalone detached signature utility',
-      '--manual', 'User Commands',
-      '--version-string', libjcat_version,
-    ],
-    install : true,
-    install_dir : join_paths(mandir, 'man1'),
+    configuration : conf,
+    install: true,
+    install_dir: join_paths(mandir, 'man1'),
   )
 endif
 


### PR DESCRIPTION
This prevents problems when cross compiling. Using help2man is now also of
limited use; if we can just tell the user to use --help we do not need to keep
the manual in sync.

See https://github.com/fwupd/fwupd/issues/3025