### PR TITLE
Update minimum meson version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libjcat', 'c',
   version : '0.1.9',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.49.2',
+  meson_version : '>=0.51.0',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 


### PR DESCRIPTION
If you check, during installation it complains about some features added only on 0.5x.y version of meson so I think it's time to update it to fix these warnings.

```
WARNING: Project targeting '>=0.49.2' but tried to use feature introduced in '0.51.0': modules arg in python.find_installation.
Program python3 (xml.etree.ElementTree, pkg_resources) found: YES (/usr/bin/python3.9) modules: xml.etree.ElementTree, pkg_resources
WARNING: Project targeting '>=0.49.2' but tried to use feature introduced in '0.50.0': install arg in configure_file.
Configuring jcat-tool.1 using configuration
Build targets in project: 5
WARNING: Project specifies a minimum meson_version '>=0.49.2' but uses features which were added in newer versions:
 * 0.50.0: {'install arg in configure_file'}
 * 0.51.0: {'modules arg in python.find_installation'}
```