### PR TITLE
build: Require Python explicitly

### DIFF
--- a/libjcat/meson.build
+++ b/libjcat/meson.build
@@ -154,7 +154,7 @@ if get_option('introspection')
   endif
 
   python = import('python')
-  python_interpreter = python.find_installation(
+  python_interpreter = python.find_installation('python3',
     modules: [
       'xml.etree.ElementTree',
       'pkg_resources',


### PR DESCRIPTION
When the first argument to python.find_installation is omitted, Meson will return the Python instance used to run it. But that can be a completely different installation than the one on PATH.

This change was initially introduced in https://github.com/hughsie/libjcat/commit/cf2d9298a5fab7278ee040bc0b4be384a7b5538e but reverted in https://github.com/hughsie/libjcat/commit/98e5b9060fd2a96d707a449635e13b5b2ffc1ecc due to concern about FreeBSD 12.2. But FreeBSD 12.2 installs python3 on PATH nowadays and even if it did not, the inability to find Python is a [bug to fix in Meson](https://github.com/mesonbuild/meson/issues/4608).

cc @Asiderr (for https://github.com/hughsie/libjcat/pull/52)