### PR TITLE
meson: use the correct lookup method for the python3 script interpreter

### DIFF
--- a/contrib/generate-version-script.py
+++ b/contrib/generate-version-script.py
@@ -8,10 +8,11 @@
 import sys
 import xml.etree.ElementTree as ET
 
-from pkg_resources import parse_version
-
 XMLNS = '{http://www.gtk.org/introspection/core/1.0}'
 XMLNS_C = '{http://www.gtk.org/introspection/c/1.0}'
+
+def parse_version(ver):
+    return tuple(map(int, ver.split('.')))
 
 def usage(return_code):
     """ print usage and exit with the supplied return code """

--- a/libjcat/meson.build
+++ b/libjcat/meson.build
@@ -153,13 +153,7 @@ if get_option('introspection')
     )
   endif
 
-  python = import('python')
-  python_interpreter = python.find_installation('python3',
-    modules: [
-      'xml.etree.ElementTree',
-      'pkg_resources',
-    ],
-  )
+  python_interpreter = find_program('python3')
 
   # Verify the map file is correct -- note we can't actually use the generated
   # file for two reasons:


### PR DESCRIPTION
The python module's find_installation method is incorrect -- it does a variety of things geared towards building and installing python modules into site-packages. This is slow and inefficient and completely pointless -- all that is needed here is to run scripts.

find_program() is guaranteed to find the python3 interpreter too, and is the correct way to find any other program, so use it for python as well.