### PR TITLE
Fix incorrect certtool being called on macOS

### DIFF
--- a/data/tests/meson.build
+++ b/data/tests/meson.build
@@ -7,7 +7,8 @@ configure_file(
 )
 
 # generate private PKCS7 key
-certtool = find_program('certtool')
+certtool = find_program('gnutls-certtool', 'certtool')
+
 pkcs7_privkey = custom_target('test-privkey.pem',
   output: 'test-privkey.pem',
   command: [certtool, '--generate-privkey', '--outfile', '@OUTPUT@'],

--- a/libjcat/jcat-self-test.c
+++ b/libjcat/jcat-self-test.c
@@ -579,8 +579,6 @@ jcat_ed25519_engine_func(void)
 	g_autofree gchar *fn_pass = NULL;
 	g_autofree gchar *fn_sig = NULL;
 	g_autofree gchar *pki_dir = NULL;
-	g_autofree gchar *sig_fn2 = NULL;
-	g_autoptr(GBytes) blob_sig2 = NULL;
 	g_autoptr(GBytes) data_fail = NULL;
 	g_autoptr(GBytes) data_fwbin = NULL;
 	g_autoptr(GBytes) data_sig = NULL;


### PR DESCRIPTION
The Apple certtool and GnuTLS certtool have different CLI options.