### PR TITLE
predate test cert activation date by 1 day

### DIFF
--- a/contrib/build-certs.py
+++ b/contrib/build-certs.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 def _build_certs():
 
     # expire in 7 days to avoid people using these in production
-    dt_activation = datetime.utcnow().isoformat()
+    dt_activation = (datetime.utcnow() - timedelta(days=1)).isoformat()
     dt_expiration = (datetime.utcnow() + timedelta(days=7)).isoformat()
 
     # certificate authority


### PR DESCRIPTION
This ensures that, no matter the local timezone, the certificates will be active as of the current time on the local machine.

This resolved #65 for me.