### PR TITLE
Fix prefix of LIBJCAT_CHECK_VERSION

### DIFF
--- a/libjcat/jcat-version.h.in
+++ b/libjcat/jcat-version.h.in
@@ -12,6 +12,8 @@
  * JCAT_MAJOR_VERSION:
  *
  * The compile-time major version
+ *
+ * Since: 0.1.0
  */
 #ifndef JCAT_MAJOR_VERSION
 #define JCAT_MAJOR_VERSION (@JCAT_MAJOR_VERSION@)
@@ -21,6 +23,8 @@
  * JCAT_MINOR_VERSION:
  *
  * The compile-time minor version
+ *
+ * Since: 0.1.0
  */
 #ifndef JCAT_MINOR_VERSION
 #define JCAT_MINOR_VERSION (@JCAT_MINOR_VERSION@)
@@ -30,24 +34,32 @@
  * JCAT_MICRO_VERSION:
  *
  * The compile-time micro version
+ *
+ * Since: 0.1.0
  */
 #ifndef JCAT_MICRO_VERSION
 #define JCAT_MICRO_VERSION (@JCAT_MICRO_VERSION@)
 #endif
 
 /**
- * LIBJCAT_CHECK_VERSION:
+ * JCAT_CHECK_VERSION:
  * @major: Major version number
  * @minor: Minor version number
  * @micro: Micro version number
  *
  * Check whether a libjcat version equal to or greater than
  * major.minor.micro.
+ *
+ * Since: 0.1.14
  */
-#define LIBJCAT_CHECK_VERSION(major, minor, micro)                                                 \
+#define JCAT_CHECK_VERSION(major, minor, micro)                                                 \
 	(JCAT_MAJOR_VERSION > (major) ||                                                           \
 	 (JCAT_MAJOR_VERSION == (major) && JCAT_MINOR_VERSION > (minor)) ||                        \
 	 (JCAT_MAJOR_VERSION == (major) && JCAT_MINOR_VERSION == (minor) &&                        \
 	  JCAT_MICRO_VERSION >= (micro)))
+
+#ifndef __GI_SCANNER__
+#define LIBJCAT_CHECK_VERSION(major, minor, micro) JCAT_CHECK_VERSION(major, minor, micro)
+#endif
 
 const gchar	*jcat_version_string	(void);


### PR DESCRIPTION
This fixes a warning about exported prefixes in gtk-doc.