### PR TITLE
Fix header includes

### DIFF
--- a/libjcat/jcat-ed25519-engine.c
+++ b/libjcat/jcat-ed25519-engine.c
@@ -6,6 +6,8 @@
 
 #include "config.h"
 
+#include <string.h>
+
 #include <gnutls/crypto.h>
 #include <nettle/eddsa.h>
 


### PR DESCRIPTION
```
[18/43] Compiling C object libjcat/cygjcat-1.dll.p/jcat-ed25519-engine.c.o
../libjcat/jcat-ed25519-engine.c: In function ‘jcat_ed25519_sig_from_bytes’:
../libjcat/jcat-ed25519-engine.c:42:9: warning: implicit declaration of function ‘memcpy’ [-Wimplicit-function-declaration]
   42 |         memcpy(privkey, g_bytes_get_data(blob, NULL), sizeof(Ed25519Sig));
      |         ^~~~~~
../libjcat/jcat-ed25519-engine.c:15:1: note: include ‘<string.h>’ or provide a declaration of ‘memcpy’
   14 | #include "jcat-engine-private.h"
  +++ |+#include <string.h>
   15 |
../libjcat/jcat-ed25519-engine.c:42:9: warning: incompatible implicit declaration of built-in function ‘memcpy’ [-Wbuiltin-declaration-mismatch]
   42 |         memcpy(privkey, g_bytes_get_data(blob, NULL), sizeof(Ed25519Sig));
      |         ^~~~~~
../libjcat/jcat-ed25519-engine.c:42:9: note: include ‘<string.h>’ or provide a declaration of ‘memcpy’
../libjcat/jcat-ed25519-engine.c: In function ‘jcat_ed25519_key_from_bytes’:
../libjcat/jcat-ed25519-engine.c:62:9: warning: incompatible implicit declaration of built-in function ‘memcpy’ [-Wbuiltin-declaration-mismatch]
   62 |         memcpy(pubkey, g_bytes_get_data(blob, NULL), sizeof(Ed25519Key));
      |         ^~~~~~
../libjcat/jcat-ed25519-engine.c:62:9: note: include ‘<string.h>’ or provide a declaration of ‘memcpy’
```