### PR TITLE
Fix various memory leaks

### DIFF
--- a/libjcat/jcat-bt-proof.c
+++ b/libjcat/jcat-bt-proof.c
@@ -330,6 +330,8 @@ jcat_bt_consistency_proof_verify(gint64 snapshot1,
 	g_autoptr(GPtrArray) proof_new = NULL;
 	g_autoptr(GByteArray) hash1 = NULL;
 	g_autoptr(GByteArray) hash2 = NULL;
+	g_autoptr(GByteArray) hash1_tmp = NULL;
+	g_autoptr(GByteArray) hash2_tmp = NULL;
 
 	if (snapshot1 < 0) {
 		g_set_error(error,
@@ -427,8 +429,8 @@ jcat_bt_consistency_proof_verify(gint64 snapshot1,
 	if (proof_right == NULL)
 		return FALSE;
 
-	hash1 = jcat_bt_hash_chain_inner_right(seed, proof_left, mask);
-	hash1 = jcat_bt_hash_chain_border_right(hash1, proof_right);
+	hash1_tmp = jcat_bt_hash_chain_inner_right(seed, proof_left, mask);
+	hash1 = jcat_bt_hash_chain_border_right(hash1_tmp, proof_right);
 	if (!jcat_byte_array_compare(hash1, root1, error)) {
 		g_autofree gchar *str1 = jcat_hex_encode_string(hash1);
 		g_autofree gchar *str2 = jcat_hex_encode_string(root1);
@@ -437,8 +439,8 @@ jcat_bt_consistency_proof_verify(gint64 snapshot1,
 	}
 
 	/* verify the second root */
-	hash2 = jcat_bt_hash_chain_inner(seed, proof_left, mask);
-	hash2 = jcat_bt_hash_chain_border_right(hash2, proof_right);
+	hash2_tmp = jcat_bt_hash_chain_inner(seed, proof_left, mask);
+	hash2 = jcat_bt_hash_chain_border_right(hash2_tmp, proof_right);
 	if (!jcat_byte_array_compare(hash2, root2, error)) {
 		g_autofree gchar *str1 = jcat_hex_encode_string(hash2);
 		g_autofree gchar *str2 = jcat_hex_encode_string(root2);

--- a/libjcat/jcat-bt-util.c
+++ b/libjcat/jcat-bt-util.c
@@ -105,6 +105,8 @@ jcat_bt_generate_key_pair(const gchar *keyname,
 	g_autofree gchar *key_hash = NULL;
 	g_autoptr(GByteArray) raw_private_key = NULL;
 	g_autoptr(GByteArray) raw_public_key = NULL;
+	g_autoptr(GBytes) public_key_result = NULL;
+	g_autoptr(GBytes) private_key_result = NULL;
 
 	g_return_val_if_fail(public_key != NULL, FALSE);
 	g_return_val_if_fail(private_key != NULL, FALSE);
@@ -130,8 +132,10 @@ jcat_bt_generate_key_pair(const gchar *keyname,
 			key_hash,
 			encoded_raw_private_key);
 	g_string_printf(public_key_string, "%s+%s+%s", keyname, key_hash, encoded_raw_public_key);
-	*private_key = g_string_free_to_bytes(private_key_string);
-	*public_key = g_string_free_to_bytes(public_key_string);
+	private_key_result = g_string_free_to_bytes(private_key_string);
+	jcat_set_bytes(private_key, private_key_result);
+	public_key_result = g_string_free_to_bytes(public_key_string);
+	jcat_set_bytes(public_key, public_key_result);
 
 	return TRUE;
 #endif

--- a/libjcat/jcat-common-private.h
+++ b/libjcat/jcat-common-private.h
@@ -31,6 +31,8 @@ guint
 jcat_inner_proof_size(guint64 index, guint64 size);
 void
 jcat_set_byte_array(GByteArray **buf, GByteArray *buf_new);
+void
+jcat_set_bytes(GBytes **buf, GBytes *buf_new);
 gboolean
 jcat_byte_array_compare(GByteArray *buf1, GByteArray *buf2, GError **error);
 gchar *

--- a/libjcat/jcat-common.c
+++ b/libjcat/jcat-common.c
@@ -236,6 +236,25 @@ jcat_set_byte_array(GByteArray **buf, GByteArray *buf_new)
 }
 
 /**
+ * jcat_set_bytes:
+ * @buf: (not nullable) (out): the buffer
+ * @buf_new: (not nullable): the new buffer contents
+ *
+ * Assign a #GBytes to another #GBytes.
+ *
+ * Since: 0.2.0
+ **/
+void
+jcat_set_bytes(GBytes **buf, GBytes *buf_new)
+{
+	if (buf_new == *buf)
+		return;
+	if (*buf != NULL)
+		g_bytes_unref(*buf);
+	*buf = g_bytes_ref(buf_new);
+}
+
+/**
  * jcat_byte_array_compare:
  * @buf1: (not nullable): the first buffer
  * @buf2: (not nullable): the second buffer

--- a/libjcat/jcat-self-test.c
+++ b/libjcat/jcat-self-test.c
@@ -2422,11 +2422,12 @@ jcat_bt_inmemory_tree_path_from_node_to_root_at_snapshot(JcatBtInmemoryTree *tre
 					    sibling)));
 		} else if (sibling == last_node) {
 			GByteArray *recomputed = NULL;
-			g_byte_array_unref(
+			g_autoptr(GByteArray) root =
 			    jcat_bt_inmemory_tree_recompute_past_snapshot(tree,
 									  snapshot,
 									  level,
-									  &recomputed));
+									  &recomputed);
+			g_assert_nonnull(root);
 			g_assert_nonnull(recomputed);
 			g_ptr_array_add(path, recomputed);
 		}

--- a/libjcat/jcat-self-test.c
+++ b/libjcat/jcat-self-test.c
@@ -1939,7 +1939,7 @@ jcat_bt_generate_corrupt_consistency_proof(gint64 snapshot1,
 		/* copy the proof */
 		GPtrArray *wrong_proof = g_ptr_array_copy(proof, (GCopyFunc)g_byte_array_ref, NULL);
 		/* and also the data inside */
-		GByteArray *good = g_ptr_array_steal_index(wrong_proof, i);
+		g_autoptr(GByteArray) good = g_ptr_array_steal_index(wrong_proof, i);
 		GByteArray *corrupt = g_byte_array_new();
 		g_byte_array_append(corrupt, good->data, good->len);
 		/* flip the bit */

--- a/libjcat/jcat-self-test.c
+++ b/libjcat/jcat-self-test.c
@@ -2422,10 +2422,11 @@ jcat_bt_inmemory_tree_path_from_node_to_root_at_snapshot(JcatBtInmemoryTree *tre
 					    sibling)));
 		} else if (sibling == last_node) {
 			GByteArray *recomputed = NULL;
-			jcat_bt_inmemory_tree_recompute_past_snapshot(tree,
-								      snapshot,
-								      level,
-								      &recomputed);
+			g_byte_array_unref(
+			    jcat_bt_inmemory_tree_recompute_past_snapshot(tree,
+									  snapshot,
+									  level,
+									  &recomputed));
 			g_assert_nonnull(recomputed);
 			g_ptr_array_add(path, recomputed);
 		}

--- a/libjcat/jcat-self-test.c
+++ b/libjcat/jcat-self-test.c
@@ -2756,6 +2756,9 @@ jcat_bt_prefix_hash_from_inclusion_proof_errors_func(void)
 	g_autoptr(GByteArray) leaf301 = NULL;
 	g_autoptr(GPtrArray) proof301 = NULL;
 	g_autoptr(GError) error = NULL;
+	g_autoptr(GByteArray) res1 = NULL;
+	g_autoptr(GByteArray) res2 = NULL;
+	g_autoptr(GByteArray) res3 = NULL;
 
 	struct idxTest {
 		gint64 index;
@@ -2785,25 +2788,33 @@ jcat_bt_prefix_hash_from_inclusion_proof_errors_func(void)
 	jcat_get_leaf_and_proof(tree, 301, &leaf301, &proof301);
 
 	for (int i = 0, end = sizeof idxTests / sizeof(struct idxTest); i < end; ++i) {
-		jcat_bt_verified_prefix_hash_from_inclusion_proof(idxTests[i].index,
-								  idxTests[i].size,
-								  proof2,
-								  root,
-								  leaf2,
-								  &error);
+		g_autoptr(GByteArray) res =
+		    jcat_bt_verified_prefix_hash_from_inclusion_proof(idxTests[i].index,
+								      idxTests[i].size,
+								      proof2,
+								      root,
+								      leaf2,
+								      &error);
 		g_assert_nonnull(error);
 		g_clear_error(&error);
 	}
 
-	jcat_bt_verified_prefix_hash_from_inclusion_proof(3, size, proof2, root, leaf2, &error);
+	res1 =
+	    jcat_bt_verified_prefix_hash_from_inclusion_proof(3, size, proof2, root, leaf2, &error);
 	g_assert_no_error(error);
 
 	/* Proof #3 has the same length, but doesn't verify against index #2.
 	 Neither does proof #301 as it has a different length.*/
-	jcat_bt_verified_prefix_hash_from_inclusion_proof(3, size, proof3, root, leaf2, &error);
+	res2 =
+	    jcat_bt_verified_prefix_hash_from_inclusion_proof(3, size, proof3, root, leaf2, &error);
 	g_assert_nonnull(error);
 	g_clear_error(&error);
-	jcat_bt_verified_prefix_hash_from_inclusion_proof(3, size, proof301, root, leaf2, &error);
+	res3 = jcat_bt_verified_prefix_hash_from_inclusion_proof(3,
+								 size,
+								 proof301,
+								 root,
+								 leaf2,
+								 &error);
 	g_assert_nonnull(error);
 	g_clear_error(&error);
 }


### PR DESCRIPTION
The function `jcat_bt_inmemory_tree_recompute_past_snapshot` is called for its output parameter, but previously its return value was simply dropped instead of unref()'ed.