### PR TITLE
Save the auto-generated private key with 0600 file permissions

### DIFF
--- a/libjcat/jcat-common-private.h
+++ b/libjcat/jcat-common-private.h
@@ -15,7 +15,7 @@
 gboolean
 jcat_mkdir_parent(const gchar *filename, GError **error) G_GNUC_NON_NULL(1);
 gboolean
-jcat_set_contents_bytes(const gchar *filename, GBytes *bytes, GError **error) G_GNUC_NON_NULL(1, 2);
+jcat_set_contents_bytes(const gchar *filename, GBytes *bytes, gint mode, GError **error) G_GNUC_NON_NULL(1, 2);
 GBytes *
 jcat_get_contents_bytes(const gchar *filename, GError **error) G_GNUC_NON_NULL(1);
 void

--- a/libjcat/jcat-common.c
+++ b/libjcat/jcat-common.c
@@ -25,7 +25,7 @@ jcat_mkdir_parent(const gchar *filename, GError **error)
 
 /* private */
 gboolean
-jcat_set_contents_bytes(const gchar *filename, GBytes *bytes, GError **error)
+jcat_set_contents_bytes(const gchar *filename, GBytes *bytes, gint mode, GError **error)
 {
 	const gchar *data;
 	gsize size;
@@ -40,7 +40,16 @@ jcat_set_contents_bytes(const gchar *filename, GBytes *bytes, GError **error)
 	}
 	data = g_bytes_get_data(bytes, &size);
 	g_debug("writing %s with %" G_GSIZE_FORMAT " bytes", filename, size);
+#if GLIB_CHECK_VERSION(2,66,0)
+	return g_file_set_contents_full(filename,
+					data,
+					size,
+					G_FILE_SET_CONTENTS_CONSISTENT,
+					mode,
+					error);
+#else
 	return g_file_set_contents(filename, data, size, error);
+#endif
 }
 
 /* private */

--- a/libjcat/jcat-ed25519-engine.c
+++ b/libjcat/jcat-ed25519-engine.c
@@ -229,10 +229,10 @@ jcat_ed25519_engine_self_sign(JcatEngine *engine, GBytes *blob, JcatSignFlags fl
 		if (!jcat_mkdir_parent(fn_privkey, error))
 			return NULL;
 		blob_privkey = jcat_ed25519_sig_to_bytes(privkey);
-		if (!jcat_set_contents_bytes(fn_privkey, blob_privkey, error))
+		if (!jcat_set_contents_bytes(fn_privkey, blob_privkey, 0600, error))
 			return NULL;
 		blob_pubkey = jcat_ed25519_key_to_bytes(pubkey);
-		if (!jcat_set_contents_bytes(fn_pubkey, blob_pubkey, error))
+		if (!jcat_set_contents_bytes(fn_pubkey, blob_pubkey, 0666, error))
 			return NULL;
 	} else {
 		blob_privkey = jcat_get_contents_bytes(fn_privkey, error);

--- a/libjcat/jcat-pkcs7-engine.c
+++ b/libjcat/jcat-pkcs7-engine.c
@@ -418,7 +418,7 @@ jcat_pkcs7_engine_self_sign(JcatEngine *engine, GBytes *blob, JcatSignFlags flag
 			return NULL;
 		if (!jcat_mkdir_parent(fn_privkey, error))
 			return NULL;
-		if (!jcat_set_contents_bytes(fn_privkey, privkey, error))
+		if (!jcat_set_contents_bytes(fn_privkey, privkey, 0600, error))
 			return NULL;
 	}
 
@@ -438,7 +438,7 @@ jcat_pkcs7_engine_self_sign(JcatEngine *engine, GBytes *blob, JcatSignFlags flag
 			return NULL;
 		if (!jcat_mkdir_parent(fn_cert, error))
 			return NULL;
-		if (!jcat_set_contents_bytes(fn_cert, cert, error))
+		if (!jcat_set_contents_bytes(fn_cert, cert, 0666, error))
 			return NULL;
 	}
 

--- a/libjcat/jcat-tool.c
+++ b/libjcat/jcat-tool.c
@@ -676,7 +676,7 @@ jcat_tool_export(JcatToolPrivate *priv, gchar **values, GError **error)
 			    ".%s",
 			    jcat_blob_kind_to_filename_ext(jcat_blob_get_kind(blob)));
 			fn = g_build_filename(priv->prefix, str->str, NULL);
-			if (!jcat_set_contents_bytes(fn, jcat_blob_get_data(blob), error))
+			if (!jcat_set_contents_bytes(fn, jcat_blob_get_data(blob), 0666, error))
 				return FALSE;
 			g_print("Wrote %s\n", fn);
 		}


### PR DESCRIPTION
Althouth it's only used for self-signing in fwupd, it's probably not a good idea to make this world-readable by default. If nothing else it'll make some EDR happy somewhere.

Fixes https://github.com/hughsie/libjcat/issues/129