### PR TITLE
Switch ED25519 support to not directly using Nettle

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -144,7 +144,6 @@ endif
 
 if get_option('ed25519')
   conf.set('ENABLE_ED25519', '1')
-  libjcat_deps += dependency('hogweed')
   libjcat_deps += dependency('gnutls')
 endif
 


### PR DESCRIPTION
Previously, libjcat linked to both GnuTLS and Nettle for ED25519
support, though it can be implemented sorely with GnuTLS. This patch
drops the direct usage of Nettle for simplicity and better ABI
compatibility, as Nettle occasionally bumps library SONAME which
requires rebuild of the binary[1].

1. https://www.lysator.liu.se/~nisse/nettle/nettle.html#Compatibility
