### PR TITLE
Skip ed25519 part of a test with -Ded25519=false

### DIFF
--- a/libjcat/jcat-self-test.c
+++ b/libjcat/jcat-self-test.c
@@ -1142,6 +1142,7 @@ jcat_bt_common_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(btcheckpoint);
 
+#ifdef ENABLE_ED25519
 	/* get engine */
 	engine = jcat_context_get_engine(context, JCAT_BLOB_KIND_ED25519, &error);
 	g_assert_no_error(error);
@@ -1162,6 +1163,7 @@ jcat_bt_common_func(void)
 					   &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(result);
+#endif
 }
 
 int


### PR DESCRIPTION
Otherwise it fails with "jcat-self-test.c:1147:jcat_bt_common_func: assertion failed (error == NULL): Jcat engine kind 'ed25519' not supported (g-io-error-quark, 1)"