### PR TITLE
Add OpenSSL PKCS-7 backend

### DIFF
--- a/libjcat/jcat-pkcs7-crypto-common.c
+++ b/libjcat/jcat-pkcs7-crypto-common.c
@@ -1,0 +1,362 @@
+/*
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2025 Colin Kinloch <colin.kinloch@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "jcat-pkcs7-crypto-common.h"
+
+#define JCAT_RSA_SIZE 3072
+// To indicate that a certificate has no well-defined expiration date
+// https://www.rfc-editor.org/rfc/rfc5280#section-4.1.2.5
+#define JCAT_X509_NOTAFTER_UNDEFINED "99991231235959Z"
+
+// TODO: ERR_pop_to_mark at the end of every function?
+
+// This allows us to use autoptr with STACK_OF(X509)
+void STACK_OF_X509_free(STACK_OF_X509 *stack)
+{
+	return sk_X509_free(stack);
+}
+
+gchar *
+jcat_pkcs7_get_errors(void)
+{
+	guint32 packed_error = ERR_peek_error();
+	g_autoptr(GString) string = g_string_new(NULL);
+	g_autoptr(BIO) string_bio = BIO_new(BIO_s_mem());
+	size_t bio_len = 0;
+	char *bio_buf = NULL;
+
+	if (packed_error == 0)
+		return NULL;
+
+	ERR_print_errors(string_bio);
+
+	bio_len = BIO_get_mem_data(string_bio, &bio_buf);
+	g_string_append_len(string, bio_buf, bio_len);
+
+	return g_strdup(string->str);
+}
+
+X509 *
+jcat_pkcs7_load_crt_from_blob_pem(GBytes *blob, GError **error)
+{
+	g_autoptr(BIO) bio_blob = NULL;
+	g_autoptr(X509) crt = NULL;
+	gsize blob_size = g_bytes_get_size(blob);
+
+	/* discard OpenSSL warning about SHA1 use from this function */
+	/* PEM_read_bio_X509 succeeds but pushes rh-allow-sha1-signatures to the error stack */
+	ERR_set_mark();
+
+	bio_blob = BIO_new_mem_buf(g_bytes_get_data(blob, NULL), blob_size);
+	if (bio_blob == NULL) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed create bio for pem: %s",
+			    error_str);
+		return NULL;
+	}
+
+	/* decode the certificate */
+	if (!PEM_read_bio_X509(bio_blob, &crt, NULL, NULL)) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed read x509 certificate from pem: %s",
+			    error_str);
+		return NULL;
+	}
+
+	ERR_pop_to_mark();
+
+	return g_steal_pointer(&crt);
+}
+
+X509 *
+jcat_pkcs7_load_crt_from_blob_der(GBytes *blob, GError **error)
+{
+	g_autoptr(BIO) bio_blob = NULL;
+	g_autoptr(X509) crt = NULL;
+	gsize blob_size = g_bytes_get_size(blob);
+	const guchar *blob_data = g_bytes_get_data(blob, NULL);
+
+	/* discard OpenSSL warning about SHA1 use from this function */
+	ERR_set_mark();
+
+	bio_blob = BIO_new_mem_buf(g_bytes_get_data(blob, NULL), blob_size);
+	if (bio_blob == NULL) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed create bio for der: %s",
+			    error_str);
+		return NULL;
+	}
+
+	/* decode the certificate */
+	if (!d2i_X509(&crt, &blob_data, blob_size)) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed read x509 certificate from der: %s",
+			    error_str);
+		return NULL;
+	}
+
+	ERR_pop_to_mark();
+
+	return g_steal_pointer(&crt);
+}
+
+EVP_PKEY *
+jcat_pkcs7_load_privkey_from_blob_pem(GBytes *blob, GError **error)
+{
+	g_autoptr(EVP_PKEY) key = NULL;
+	g_autoptr(OSSL_DECODER_CTX) dec_ctx = NULL;
+	gsize blob_size;
+	const guchar *blob_data = g_bytes_get_data(blob, &blob_size);
+
+	dec_ctx = OSSL_DECODER_CTX_new_for_pkey(&key, "PEM", NULL,
+		"RSA", OSSL_KEYMGMT_SELECT_KEYPAIR, NULL, NULL);
+
+	if (dec_ctx == NULL) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed setup keypair decoder: %s",
+			    error_str);
+		return NULL;
+	}
+
+	if (!OSSL_DECODER_from_data(dec_ctx, &blob_data, &blob_size)) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to decode keypair: %s",
+			    error_str);
+		return NULL;
+	}
+
+	return g_steal_pointer(&key);
+}
+
+/* generates a private key just like `certtool --generate-privkey` */
+GBytes *
+jcat_pkcs7_create_private_key(GError **error)
+{
+	g_autoptr(EVP_PKEY) pkey = NULL;
+	g_autoptr(EVP_PKEY_CTX) ctx = NULL;
+	g_autoptr(OSSL_ENCODER_CTX) enc_ctx = NULL;
+	g_autoptr(BIO) pkey_bio = BIO_new(BIO_s_mem());
+	g_autofree guchar *pem_data = NULL;
+	gsize pem_data_size = 0;
+
+	ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+
+	if (!ctx) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to gen: %s",
+			    error_str);
+		return NULL;
+	}
+
+	if (EVP_PKEY_keygen_init(ctx) <= 0) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to init keygen: %s",
+			    error_str);
+		return NULL;
+	}
+
+	if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, JCAT_RSA_SIZE) <= 0) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to set keygen bits: %s",
+			    error_str);
+		return NULL;
+	}
+
+	/* generate key */
+	if (EVP_PKEY_keygen(ctx, &pkey) <= 0) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to generate key: %s",
+			    error_str);
+		return NULL;
+	}
+
+	enc_ctx = OSSL_ENCODER_CTX_new_for_pkey(pkey, EVP_PKEY_KEYPAIR,
+		"PEM", NULL, NULL);
+	if (enc_ctx == NULL) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to create an encoder for privkey: %s",
+			    error_str);
+		return NULL;
+	}
+
+	if (OSSL_ENCODER_to_data(enc_ctx, &pem_data, &pem_data_size) == 0) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to encode privkey: %s",
+			    error_str);
+		return NULL;
+	}
+
+	return g_bytes_new_take(g_steal_pointer(&pem_data), pem_data_size);
+}
+
+/* generates a self signed certificate just like:
+ *  `certtool --generate-self-signed --load-privkey priv.pem` */
+GBytes *
+jcat_pkcs7_create_client_certificate(EVP_PKEY *privkey, GError **error)
+{
+	g_autoptr(BIGNUM) sha1bn = BN_new();
+	g_autoptr(X509) crt = X509_new();
+	g_autoptr(BIO) crt_bio = BIO_new(BIO_s_mem());
+	g_autoptr(BASIC_CONSTRAINTS) bcons = BASIC_CONSTRAINTS_new();
+	g_autoptr(ASN1_INTEGER) usage = ASN1_INTEGER_new();
+	g_autoptr(ASN1_OCTET_STRING) skid = ASN1_OCTET_STRING_new();
+	const guchar *crt_buf;
+	guchar md[EVP_MAX_MD_SIZE];
+	gsize crt_size;
+	guint md_size = 0;
+
+	/* set public key */
+	if (!X509_set_pubkey(crt, privkey)) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to set client cert public key: %s",
+			    error_str);
+		return NULL;
+	}
+
+	/* set positive random serial number */
+	/* generate random number 1 bit short of 20 bytes so that it becomes positive (OpenSSL does this) */
+	if (!BN_rand(sha1bn, (20 * 8) - 1, BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY)) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to generate cert serial number: %s",
+			    error_str);
+		return NULL;
+	}
+	if (!BN_to_ASN1_INTEGER(sha1bn, X509_get_serialNumber(crt))) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to set serial number: %s",
+			    error_str);
+		return NULL;
+	}
+
+	/* set activation */
+	if (!ASN1_TIME_set(X509_getm_notBefore(crt), time(NULL))) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to set client cert activation time: %s",
+			    error_str);
+		return NULL;
+	}
+
+	/* set expiration */
+	if (!ASN1_TIME_set_string(X509_getm_notAfter(crt), JCAT_X509_NOTAFTER_UNDEFINED)) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to set client cert expiration time: %s",
+			    error_str);
+		return NULL;
+	}
+
+	/* set basic constraints */
+	bcons->ca = FALSE;
+	if (X509_add1_ext_i2d(crt, NID_basic_constraints, bcons, 1, X509V3_ADD_DEFAULT) < 1) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+				G_IO_ERROR,
+				G_IO_ERROR_INVALID_DATA,
+				"failed to add basic constraints to cert: %s",
+				error_str);
+		return NULL;
+	}
+
+	/* set usage */
+	ASN1_INTEGER_set(usage, KU_DIGITAL_SIGNATURE);
+	if (X509_add1_ext_i2d(crt, NID_key_usage, usage, 1, X509V3_ADD_DEFAULT) < 1) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+				G_IO_ERROR,
+				G_IO_ERROR_INVALID_DATA,
+				"failed to add key usage to cert: %s",
+				error_str);
+		return NULL;
+	}
+
+	/* set subject key ID */
+	if (!X509_pubkey_digest(crt, EVP_sha1(), md, &md_size)) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+				G_IO_ERROR,
+				G_IO_ERROR_INVALID_DATA,
+				"failed to create digest of certs pubkey: %s",
+				error_str);
+		return NULL;
+	}
+	ASN1_OCTET_STRING_set(skid, md, md_size);
+	if (X509_add1_ext_i2d(crt, NID_subject_key_identifier, skid, 0, X509V3_ADD_DEFAULT) < 1) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+				G_IO_ERROR,
+				G_IO_ERROR_INVALID_DATA,
+				"failed to add signer key id to cert: %s",
+				error_str);
+		return NULL;
+	}
+
+	/* set version */
+	X509_set_version(crt, X509_VERSION_3);
+
+	/* self-sign certificate */
+	X509_sign(crt, privkey, EVP_sha256());
+
+	/* encode as PEM */
+	PEM_write_bio_X509(crt_bio, crt);
+
+	crt_size = BIO_get_mem_data(crt_bio, &crt_buf);
+	return g_bytes_new(crt_buf, crt_size);
+}

--- a/libjcat/jcat-pkcs7-crypto-common.c
+++ b/libjcat/jcat-pkcs7-crypto-common.c
@@ -17,7 +17,8 @@
 // TODO: ERR_pop_to_mark at the end of every function?
 
 // This allows us to use autoptr with STACK_OF(X509)
-void STACK_OF_X509_free(STACK_OF_X509 *stack)
+void
+STACK_OF_X509_free(STACK_OF_X509 *stack)
 {
 	return sk_X509_free(stack);
 }
@@ -127,8 +128,13 @@ jcat_pkcs7_load_privkey_from_blob_pem(GBytes *blob, GError **error)
 	gsize blob_size;
 	const guchar *blob_data = g_bytes_get_data(blob, &blob_size);
 
-	dec_ctx = OSSL_DECODER_CTX_new_for_pkey(&key, "PEM", NULL,
-		"RSA", OSSL_KEYMGMT_SELECT_KEYPAIR, NULL, NULL);
+	dec_ctx = OSSL_DECODER_CTX_new_for_pkey(&key,
+						"PEM",
+						NULL,
+						"RSA",
+						OSSL_KEYMGMT_SELECT_KEYPAIR,
+						NULL,
+						NULL);
 
 	if (dec_ctx == NULL) {
 		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
@@ -208,8 +214,7 @@ jcat_pkcs7_create_private_key(GError **error)
 		return NULL;
 	}
 
-	enc_ctx = OSSL_ENCODER_CTX_new_for_pkey(pkey, EVP_PKEY_KEYPAIR,
-		"PEM", NULL, NULL);
+	enc_ctx = OSSL_ENCODER_CTX_new_for_pkey(pkey, EVP_PKEY_KEYPAIR, "PEM", NULL, NULL);
 	if (enc_ctx == NULL) {
 		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
 		g_set_error(error,
@@ -261,7 +266,8 @@ jcat_pkcs7_create_client_certificate(EVP_PKEY *privkey, GError **error)
 	}
 
 	/* set positive random serial number */
-	/* generate random number 1 bit short of 20 bytes so that it becomes positive (OpenSSL does this) */
+	/* generate random number 1 bit short of 20 bytes so that it's MSb is 0 (it's positive)
+	 * This matches the OpenSSL implementation */
 	if (!BN_rand(sha1bn, (20 * 8) - 1, BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY)) {
 		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
 		g_set_error(error,
@@ -308,10 +314,10 @@ jcat_pkcs7_create_client_certificate(EVP_PKEY *privkey, GError **error)
 	if (X509_add1_ext_i2d(crt, NID_basic_constraints, bcons, 1, X509V3_ADD_DEFAULT) < 1) {
 		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
 		g_set_error(error,
-				G_IO_ERROR,
-				G_IO_ERROR_INVALID_DATA,
-				"failed to add basic constraints to cert: %s",
-				error_str);
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to add basic constraints to cert: %s",
+			    error_str);
 		return NULL;
 	}
 
@@ -320,10 +326,10 @@ jcat_pkcs7_create_client_certificate(EVP_PKEY *privkey, GError **error)
 	if (X509_add1_ext_i2d(crt, NID_key_usage, usage, 1, X509V3_ADD_DEFAULT) < 1) {
 		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
 		g_set_error(error,
-				G_IO_ERROR,
-				G_IO_ERROR_INVALID_DATA,
-				"failed to add key usage to cert: %s",
-				error_str);
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to add key usage to cert: %s",
+			    error_str);
 		return NULL;
 	}
 
@@ -331,20 +337,20 @@ jcat_pkcs7_create_client_certificate(EVP_PKEY *privkey, GError **error)
 	if (!X509_pubkey_digest(crt, EVP_sha1(), md, &md_size)) {
 		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
 		g_set_error(error,
-				G_IO_ERROR,
-				G_IO_ERROR_INVALID_DATA,
-				"failed to create digest of certs pubkey: %s",
-				error_str);
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to create digest of certs pubkey: %s",
+			    error_str);
 		return NULL;
 	}
 	ASN1_OCTET_STRING_set(skid, md, md_size);
 	if (X509_add1_ext_i2d(crt, NID_subject_key_identifier, skid, 0, X509V3_ADD_DEFAULT) < 1) {
 		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
 		g_set_error(error,
-				G_IO_ERROR,
-				G_IO_ERROR_INVALID_DATA,
-				"failed to add signer key id to cert: %s",
-				error_str);
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to add signer key id to cert: %s",
+			    error_str);
 		return NULL;
 	}
 

--- a/libjcat/jcat-pkcs7-crypto-common.h
+++ b/libjcat/jcat-pkcs7-crypto-common.h
@@ -10,24 +10,30 @@
 // Maybe remove this or set OPENSSL_API_COMPAT to a reasonable version
 #define OPENSSL_NO_DEPRECATED
 
-#include <openssl/crypto.h>
+/* PEM_read_bio_CMS is generated in cms.h by macros defined in pem.h */
+// clang-format off
 #include <openssl/pem.h>
-#include <openssl/x509.h>
-#include <openssl/x509v3.h>
-#include <openssl/x509_vfy.h>
-#include <openssl/pkcs7.h>
+
 #include <openssl/cms.h>
-#include <openssl/evp.h>
-#include <openssl/rsa.h>
-#include <openssl/rand.h>
+// clang-format on
+
+#include <openssl/crypto.h>
 #include <openssl/decoder.h>
 #include <openssl/encoder.h>
 #include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/pkcs7.h>
+#include <openssl/rand.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+#include <openssl/x509_vfy.h>
+#include <openssl/x509v3.h>
 
 #include "jcat-compile.h"
 
 typedef STACK_OF(X509) STACK_OF_X509;
-void STACK_OF_X509_free(STACK_OF_X509 *stack);
+void
+STACK_OF_X509_free(STACK_OF_X509 *stack);
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"

--- a/libjcat/jcat-pkcs7-crypto-common.h
+++ b/libjcat/jcat-pkcs7-crypto-common.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2025 Colin Kinloch <colin.kinloch@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+// Maybe remove this or set OPENSSL_API_COMPAT to a reasonable version
+#define OPENSSL_NO_DEPRECATED
+
+#include <openssl/crypto.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/x509_vfy.h>
+#include <openssl/pkcs7.h>
+#include <openssl/cms.h>
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+#include <openssl/rand.h>
+#include <openssl/decoder.h>
+#include <openssl/encoder.h>
+#include <openssl/err.h>
+
+#include "jcat-compile.h"
+
+typedef STACK_OF(X509) STACK_OF_X509;
+void STACK_OF_X509_free(STACK_OF_X509 *stack);
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(BIO, BIO_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(X509, X509_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(X509_STORE, X509_STORE_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(X509_VERIFY_PARAM, X509_VERIFY_PARAM_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(X509_PUBKEY, X509_PUBKEY_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(X509_EXTENSION, X509_EXTENSION_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(STACK_OF_X509, STACK_OF_X509_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(PKCS7, PKCS7_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(CMS_ContentInfo, CMS_ContentInfo_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(OSSL_DECODER_CTX, OSSL_DECODER_CTX_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(OSSL_ENCODER_CTX, OSSL_ENCODER_CTX_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(EVP_PKEY, EVP_PKEY_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(EVP_PKEY_CTX, EVP_PKEY_CTX_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(BIGNUM, BN_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(ASN1_INTEGER, ASN1_INTEGER_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(ASN1_TIME, ASN1_TIME_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(ASN1_OCTET_STRING, ASN1_OCTET_STRING_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(BASIC_CONSTRAINTS, BASIC_CONSTRAINTS_free)
+#pragma clang diagnostic pop
+
+X509 *
+jcat_pkcs7_load_crt_from_blob_pem(GBytes *blob, GError **error) G_GNUC_NON_NULL(1);
+X509 *
+jcat_pkcs7_load_crt_from_blob_der(GBytes *blob, GError **error) G_GNUC_NON_NULL(1);
+EVP_PKEY *
+jcat_pkcs7_load_privkey_from_blob_pem(GBytes *blob, GError **error) G_GNUC_NON_NULL(1);
+
+GBytes *
+jcat_pkcs7_create_private_key(GError **error);
+GBytes *
+jcat_pkcs7_create_client_certificate(EVP_PKEY *privkey, GError **error) G_GNUC_NON_NULL(1);
+
+gchar *
+jcat_pkcs7_get_errors(void);
+GBytes *
+jcat_pkcs7_bio_to_bytes(BIO *bio);

--- a/libjcat/jcat-pkcs7-crypto-engine.c
+++ b/libjcat/jcat-pkcs7-crypto-engine.c
@@ -341,9 +341,10 @@ jcat_pkcs7_engine_pubkey_sign(JcatEngine *engine,
 	g_autoptr(CMS_ContentInfo) cms_ci = NULL;
 	g_autoptr(BIO) blob_bio = NULL;
 	g_autoptr(BIO) sig_bio = NULL;
+	g_autoptr(GString) rewrap = NULL;
 	gchar *bio_buf;
 	gsize bio_len;
-	guint signing_flags = CMS_DETACHED | CMS_NOSMIMECAP;
+	guint signing_flags = CMS_BINARY | CMS_DETACHED | CMS_NOSMIMECAP;
 
 	/* nothing to do */
 	if (g_bytes_get_size(blob) == 0) {
@@ -391,7 +392,10 @@ jcat_pkcs7_engine_pubkey_sign(JcatEngine *engine,
 
 	bio_len = BIO_get_mem_data(sig_bio, &bio_buf);
 
-	return jcat_blob_new_utf8(JCAT_BLOB_KIND_PKCS7, g_strndup((const gchar *)bio_buf, bio_len));
+	rewrap = g_string_new_len(bio_buf, bio_len);
+	g_string_replace(rewrap, " CMS-----", " PKCS7-----", 0);
+
+	return jcat_blob_new_utf8(JCAT_BLOB_KIND_PKCS7, rewrap->str);
 }
 
 /* creates a detached signature just like:

--- a/libjcat/jcat-pkcs7-crypto-engine.c
+++ b/libjcat/jcat-pkcs7-crypto-engine.c
@@ -343,7 +343,7 @@ jcat_pkcs7_engine_pubkey_sign(JcatEngine *engine,
 	g_autoptr(BIO) sig_bio = NULL;
 	gchar *bio_buf;
 	gsize bio_len;
-	guint signing_flags = CMS_DETACHED;
+	guint signing_flags = CMS_DETACHED | CMS_NOSMIMECAP;
 
 	/* nothing to do */
 	if (g_bytes_get_size(blob) == 0) {

--- a/libjcat/jcat-pkcs7-crypto-engine.c
+++ b/libjcat/jcat-pkcs7-crypto-engine.c
@@ -1,0 +1,488 @@
+/*
+ * Copyright (C) 2017-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2025 Colin Kinloch <colin.kinloch@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "jcat-common-private.h"
+#include "jcat-engine-private.h"
+#include "jcat-pkcs7-crypto-common.h"
+#include "jcat-pkcs7-crypto-engine.h"
+
+struct _JcatPkcs7Engine {
+	JcatEngine parent_instance;
+	X509_STORE *trust_store;
+};
+
+G_DEFINE_TYPE(JcatPkcs7Engine, jcat_pkcs7_engine, JCAT_TYPE_ENGINE)
+
+
+static gboolean
+jcat_pkcs7_engine_add_pubkey_x509(JcatPkcs7Engine *self,
+				      X509 *crt,
+				      GError **error)
+{
+	guint32 key_usage = X509_get_key_usage(crt);
+
+	if ((key_usage & X509v3_KU_DIGITAL_SIGNATURE) == 0 &&
+		(key_usage & X509v3_KU_KEY_CERT_SIGN) == 0) {
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "certificate not suitable for use [0x%x]",
+			    key_usage);
+		return FALSE;
+	}
+
+	if (!X509_STORE_add_cert(self->trust_store, crt)) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed add x509 certificate to the trust store: %s",
+			    error_str);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+jcat_pkcs7_engine_add_public_key_raw(JcatEngine *engine, GBytes *blob, GError **error)
+{
+	JcatPkcs7Engine *self = JCAT_PKCS7_ENGINE(engine);
+	g_autoptr(X509) cert = jcat_pkcs7_load_crt_from_blob_pem(blob, error);
+	if (cert == NULL) {
+		return FALSE;
+	}
+
+	return jcat_pkcs7_engine_add_pubkey_x509(self, cert, error);
+}
+
+static gboolean
+jcat_pkcs7_engine_add_public_key(JcatEngine *engine, const gchar *filename, GError **error)
+{
+	JcatPkcs7Engine *self = JCAT_PKCS7_ENGINE(engine);
+	g_autoptr(X509) crt = NULL;
+
+	/* search all the public key files */
+	if (g_str_has_suffix(filename, ".pem")) {
+		g_autoptr(GBytes) blob = jcat_get_contents_bytes(filename, error);
+		if (blob == NULL)
+			return FALSE;
+		crt = jcat_pkcs7_load_crt_from_blob_pem(blob, error);
+		if (crt == NULL) {
+			return FALSE;
+		}
+		if (!jcat_pkcs7_engine_add_pubkey_x509(self, crt, error)) {
+			return FALSE;
+		}
+	} else if (g_str_has_suffix(filename, ".cer") || g_str_has_suffix(filename, ".crt") ||
+		   g_str_has_suffix(filename, ".der")) {
+		g_autoptr(GBytes) blob = jcat_get_contents_bytes(filename, error);
+		if (blob == NULL)
+			return FALSE;
+		crt = jcat_pkcs7_load_crt_from_blob_der(blob, error);
+		if (crt == NULL) {
+			return FALSE;
+		}
+		if (!jcat_pkcs7_engine_add_pubkey_x509(self, crt, error)) {
+			return FALSE;
+		}
+	} else {
+		g_autofree gchar *basename = g_path_get_basename(filename);
+		g_debug("ignoring %s as not PKCS-7 certificate", basename);
+	}
+
+	return TRUE;
+}
+
+static gboolean
+jcat_pkcs7_engine_setup(JcatEngine *engine, GError **error)
+{
+	JcatPkcs7Engine *self = JCAT_PKCS7_ENGINE(engine);
+
+	if (self->trust_store != NULL)
+		return TRUE;
+
+	self->trust_store = X509_STORE_new();
+
+	if (self->trust_store == NULL) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to create x509 store: %s",
+			    error_str);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/* verifies a detached signature just like:
+ *  `certtool --p7-verify --load-certificate client.pem --infile=test.p7b` */
+static JcatResult *
+jcat_pkcs7_engine_verify(JcatEngine *engine,
+			 GBytes *blob,
+			 GBytes *blob_signature,
+			 X509 *crt,
+			 JcatVerifyFlags flags,
+			 GError **error)
+{
+	JcatPkcs7Engine *self = JCAT_PKCS7_ENGINE(engine);
+	g_autoptr(CMS_ContentInfo) cms = NULL;
+	STACK_OF(CMS_SignerInfo) *infos = NULL;
+	gsize blob_size = 0;
+	gsize sig_size = 0;
+	int rc;
+	int verify_flags = CMS_BINARY;
+	g_autoptr(BIO) bio = NULL;
+	g_autoptr(BIO) bio_signature = NULL;
+	gint64 timestamp_newest = 0;
+	g_autoptr(GString) authority_newest = g_string_new(NULL);
+	g_autoptr(OSSL_DECODER_CTX) dctx = OSSL_DECODER_CTX_new();
+
+	/* import the signature */
+	sig_size = g_bytes_get_size(blob_signature);
+	bio_signature = BIO_new_mem_buf(g_bytes_get_data(blob_signature, NULL), sig_size);
+	cms = PEM_read_bio_CMS(bio_signature, &cms, NULL, NULL);
+	if (cms == NULL) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "failed to parse pkcs7 pem: %s",
+			    error_str);
+		return NULL;
+	}
+
+	/* configure trust store for verification */
+	{
+		X509_VERIFY_PARAM *param = X509_STORE_get0_param(self->trust_store);
+		/* without setting this the LVFS-CA.pem can't be used to for verify CMS */
+		X509_VERIFY_PARAM_set_purpose(param, X509_PURPOSE_ANY);
+
+		/* use with care */
+		if (flags & JCAT_VERIFY_FLAG_DISABLE_TIME_CHECKS) {
+			g_debug("WARNING: disabling time checks");
+			X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_NO_CHECK_TIME);
+		} else {
+			X509_VERIFY_PARAM_clear_flags(param, X509_V_FLAG_NO_CHECK_TIME);
+		}
+	}
+
+	/* verify the blob */
+	blob_size = g_bytes_get_size(blob);
+	bio = BIO_new_mem_buf(g_bytes_get_data(blob, NULL), blob_size);
+	if (crt != NULL) {
+		g_autoptr(STACK_OF_X509) signer_certs = sk_X509_new_null();
+		sk_X509_push(signer_certs, crt);
+
+		// TODO: Make sure that this actually verifys what we want to verify
+		/* setting this based on CMS_NOCERTS in pubkey_sign. Maybe redundant with CMS_NO_SIGNER_CERT_VERIFY */
+		verify_flags |= CMS_NOINTERN;
+		/* setting this to allow self signed certs */
+		verify_flags |= CMS_NO_SIGNER_CERT_VERIFY;
+		rc = CMS_verify(cms, signer_certs, NULL, bio, NULL, verify_flags);
+	} else {
+		rc = CMS_verify(cms, NULL, self->trust_store, bio, NULL, verify_flags);
+	}
+
+	if (rc <= 0) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_INVALID_DATA,
+			    "pkcs7 verification failed: %s",
+			    error_str);
+		return NULL;
+	}
+
+	/* save details about the key for the result */
+	infos = CMS_get0_SignerInfos(cms);
+	for (int i = 0; i < sk_CMS_SignerInfo_num(infos); i++)
+	{
+		CMS_SignerInfo *info = sk_CMS_SignerInfo_value(infos, i);
+		g_autoptr(BIO) time_bio = NULL;
+		struct tm time_tm;
+		time_t signing_time;
+		int stime_loc = CMS_signed_get_attr_by_NID(info, NID_pkcs9_signingTime, -1);
+		X509_ATTRIBUTE* stime_attr = CMS_signed_get_attr(info, stime_loc);
+		ASN1_TYPE* stime = X509_ATTRIBUTE_get0_type(stime_attr, 0);
+		ASN1_TIME *t = NULL;
+		if (stime && (stime->type == V_ASN1_UTCTIME || stime->type == V_ASN1_GENERALIZEDTIME)) {
+			t = (ASN1_TIME*) stime->value.asn1_value;
+		} else {
+				g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+				g_set_error(error,
+						G_IO_ERROR,
+						G_IO_ERROR_INVALID_DATA,
+						"failed to extract timestamp: %s",
+						error_str);
+			return NULL;
+		}
+
+		if (!ASN1_TIME_to_tm(t, &time_tm)) {
+				g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+				g_set_error(error,
+						G_IO_ERROR,
+						G_IO_ERROR_INVALID_DATA,
+						"failed to convert timestamp: %s",
+						error_str);
+			return NULL;
+		}
+
+		signing_time = mktime(&time_tm);
+
+		if (signing_time > timestamp_newest) {
+			g_autoptr(BIO) issuer_bio = BIO_new(BIO_s_mem());
+			X509_NAME *issuer_name = NULL;
+			gchar *issuer_string = NULL;
+			gsize issuer_size;
+
+			timestamp_newest = signing_time;
+
+			if (!CMS_SignerInfo_get0_signer_id(info, NULL, &issuer_name, NULL)) {
+				g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+				g_set_error(error,
+					G_IO_ERROR,
+					G_IO_ERROR_INVALID_DATA,
+					"failed to get CMS signer id: %s",
+					error_str);
+				return NULL;
+			}
+
+			if (X509_NAME_print_ex(issuer_bio, issuer_name, 0, XN_FLAG_RFC2253) == -1) {
+				g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+				g_set_error(error,
+					G_IO_ERROR,
+					G_IO_ERROR_INVALID_DATA,
+					"failed to parse certificate issuer a: %s",
+					error_str);
+				return NULL;
+			}
+
+			issuer_size = BIO_get_mem_data(issuer_bio, &issuer_string);
+			g_strndup(issuer_string, issuer_size);
+
+			if (issuer_size > 0 && issuer_string != NULL) {
+				/* issuer name isn't null terminated */
+				g_string_overwrite_len(authority_newest, 0, issuer_string, issuer_size);
+				g_string_truncate(authority_newest, issuer_size);
+			}
+		}
+	}
+
+	/* success */
+	return JCAT_RESULT(g_object_new(JCAT_TYPE_RESULT,
+					"engine",
+					engine,
+					"timestamp",
+					timestamp_newest,
+					"authority",
+					authority_newest->str,
+					NULL));
+}
+
+/* verifies a detached signature just like:
+ *  `certtool --p7-verify --load-certificate client.pem --infile=test.p7b` */
+static JcatResult *
+jcat_pkcs7_engine_self_verify(JcatEngine *engine,
+			      GBytes *blob,
+			      GBytes *blob_signature,
+			      JcatVerifyFlags flags,
+			      GError **error)
+{
+	g_autofree gchar *filename = NULL;
+	g_autoptr(X509) crt = NULL;
+	g_autoptr(GBytes) cert_blob = NULL;
+
+	filename =
+	    g_build_filename(jcat_engine_get_keyring_path(engine), "pki", "client.pem", NULL);
+	cert_blob = jcat_get_contents_bytes(filename, error);
+	if (cert_blob == NULL)
+		return NULL;
+	crt = jcat_pkcs7_load_crt_from_blob_pem(cert_blob, error);
+	if (crt == NULL)
+		return NULL;
+
+	return jcat_pkcs7_engine_verify(engine, blob, blob_signature, crt, flags, error);
+}
+
+/* verifies a detached signature just like:
+ *  `certtool --p7-verify --load-certificate client.pem --infile=test.p7b` */
+static JcatResult *
+jcat_pkcs7_engine_pubkey_verify(JcatEngine *engine,
+				GBytes *blob,
+				GBytes *blob_signature,
+				JcatVerifyFlags flags,
+				GError **error)
+{
+	return jcat_pkcs7_engine_verify(engine, blob, blob_signature, NULL, flags, error);
+}
+
+static JcatBlob *
+jcat_pkcs7_engine_pubkey_sign(JcatEngine *engine,
+			      GBytes *blob,
+			      GBytes *cert,
+			      GBytes *privkey,
+			      JcatSignFlags flags,
+			      GError **error)
+{
+	g_autoptr(EVP_PKEY) key = NULL;
+	g_autoptr(X509) crt = NULL;
+	guint signing_flags = CMS_DETACHED;
+
+	/* nothing to do */
+	if (g_bytes_get_size(blob) == 0) {
+		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT, "nothing to do");
+		return NULL;
+	}
+
+	/* load keys */
+	key = jcat_pkcs7_load_privkey_from_blob_pem(privkey, error);
+	if (key == NULL)
+		return NULL;
+	crt = jcat_pkcs7_load_crt_from_blob_pem(cert, error);
+	if (crt == NULL)
+		return NULL;
+
+
+	/* get the digest algorithm from the public key */
+	// TODO: The gnutls uses the keys "preferred_hash_algorithm". Port that if necissary.
+	// gchar mdname[256] = {0};
+	// gint default_digest_nid = 0;
+	// EVP_PKEY_get_default_digest_name(key, mdname, sizeof(mdname));
+	// EVP_PKEY_get_default_digest_nid(key, &default_digest_nid);
+	// g_debug("pubkey_sign pref digest %s %d", mdname, default_digest_nid);
+
+	/* sign data */
+	// TODO: Implement these sign ing flags
+	// TODO: CMS_NO_SIGNING_TIME was added in OpenSSL 3.5
+	//if (!(flags & JCAT_SIGN_FLAG_ADD_TIMESTAMP))
+	//	signing_flags |= CMS_NO_SIGNING_TIME;
+	if (!(flags & JCAT_SIGN_FLAG_ADD_CERT))
+		signing_flags |= CMS_NOCERTS;
+	g_autoptr(BIO) blob_bio = BIO_new_mem_buf(g_bytes_get_data(blob, NULL), g_bytes_get_size(blob));
+	g_autoptr(CMS_ContentInfo) cms_ci = CMS_sign(crt, key, NULL, blob_bio, signing_flags);
+
+	g_autoptr(BIO) sig_bio = BIO_new(BIO_s_mem());
+
+	if (!PEM_write_bio_CMS(sig_bio, cms_ci)) {
+		g_autofree gchar *error_str = jcat_pkcs7_get_errors();
+		g_set_error(error,
+			G_IO_ERROR,
+			G_IO_ERROR_INVALID_DATA,
+			"failed to encode pkcs7 as pem: %s",
+			error_str);
+		return NULL;
+	}
+
+	gchar* bio_buf;
+	gsize bio_len = BIO_get_mem_data(sig_bio, &bio_buf);
+	gchar *str = g_strndup((const gchar *)bio_buf, bio_len);
+
+	return jcat_blob_new_utf8(JCAT_BLOB_KIND_PKCS7, str);
+}
+
+/* creates a detached signature just like:
+ *  `certtool --p7-detached-sign --load-certificate client.pem \
+ *    --load-privkey secret.pem --outfile=test.p7b` */
+static JcatBlob *
+jcat_pkcs7_engine_self_sign(JcatEngine *engine, GBytes *blob, JcatSignFlags flags, GError **error)
+{
+	g_autofree gchar *fn_cert = NULL;
+	g_autofree gchar *fn_privkey = NULL;
+	g_autoptr(GBytes) cert = NULL;
+	g_autoptr(GBytes) privkey = NULL;
+
+	/* check private key exists, otherwise generate and save */
+	fn_privkey =
+	    g_build_filename(jcat_engine_get_keyring_path(engine), "pki", "secret.key", NULL);
+	if (g_file_test(fn_privkey, G_FILE_TEST_EXISTS)) {
+		privkey = jcat_get_contents_bytes(fn_privkey, error);
+		if (privkey == NULL)
+			return NULL;
+	} else {
+		privkey = jcat_pkcs7_create_private_key(error);
+		if (privkey == NULL)
+			return NULL;
+		if (!jcat_mkdir_parent(fn_privkey, error))
+			return NULL;
+		if (!jcat_set_contents_bytes(fn_privkey, privkey, 0600, error))
+			return NULL;
+	}
+
+	/* check client certificate exists, otherwise generate and save */
+	fn_cert = g_build_filename(jcat_engine_get_keyring_path(engine), "pki", "client.pem", NULL);
+	if (g_file_test(fn_cert, G_FILE_TEST_EXISTS)) {
+		cert = jcat_get_contents_bytes(fn_cert, error);
+		if (cert == NULL)
+			return NULL;
+	} else {
+		g_autoptr(EVP_PKEY) key = NULL;
+		key = jcat_pkcs7_load_privkey_from_blob_pem(privkey, error);
+		if (key == NULL)
+			return NULL;
+		cert = jcat_pkcs7_create_client_certificate(key, error);
+		if (cert == NULL)
+			return NULL;
+		if (!jcat_mkdir_parent(fn_cert, error))
+			return NULL;
+		if (!jcat_set_contents_bytes(fn_cert, cert, 0666, error))
+			return NULL;
+	}
+
+	/* sign */
+	return jcat_pkcs7_engine_pubkey_sign(engine, blob, cert, privkey, flags, error);
+}
+
+static void
+jcat_pkcs7_engine_finalize(GObject *object)
+{
+	JcatPkcs7Engine *self = JCAT_PKCS7_ENGINE(object);
+
+	X509_STORE_free(self->trust_store);
+
+	G_OBJECT_CLASS(jcat_pkcs7_engine_parent_class)->finalize(object);
+}
+
+static void
+jcat_pkcs7_engine_class_init(JcatPkcs7EngineClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	JcatEngineClass *klass_app = JCAT_ENGINE_CLASS(klass);
+	klass_app->setup = jcat_pkcs7_engine_setup;
+	klass_app->add_public_key = jcat_pkcs7_engine_add_public_key;
+	klass_app->add_public_key_raw = jcat_pkcs7_engine_add_public_key_raw;
+	klass_app->pubkey_verify = jcat_pkcs7_engine_pubkey_verify;
+	klass_app->pubkey_sign = jcat_pkcs7_engine_pubkey_sign;
+	klass_app->self_verify = jcat_pkcs7_engine_self_verify;
+	klass_app->self_sign = jcat_pkcs7_engine_self_sign;
+	object_class->finalize = jcat_pkcs7_engine_finalize;
+}
+
+static void
+jcat_pkcs7_engine_init(JcatPkcs7Engine *self)
+{
+}
+
+JcatEngine *
+jcat_pkcs7_engine_new(JcatContext *context)
+{
+	g_return_val_if_fail(JCAT_IS_CONTEXT(context), NULL);
+	return JCAT_ENGINE(g_object_new(JCAT_TYPE_PKCS7_ENGINE,
+					"context",
+					context,
+					"kind",
+					JCAT_BLOB_KIND_PKCS7,
+					"method",
+					JCAT_BLOB_METHOD_SIGNATURE,
+					NULL));
+}

--- a/libjcat/jcat-pkcs7-crypto-engine.h
+++ b/libjcat/jcat-pkcs7-crypto-engine.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2017-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2025 Colin Kinloch <colin.kinloch@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include "jcat-context.h"
+#include "jcat-engine.h"
+
+#define JCAT_TYPE_PKCS7_ENGINE (jcat_pkcs7_engine_get_type())
+
+G_DECLARE_FINAL_TYPE(JcatPkcs7Engine, jcat_pkcs7_engine, JCAT, PKCS7_ENGINE, JcatEngine)
+
+JcatEngine *
+jcat_pkcs7_engine_new(JcatContext *context) G_GNUC_NON_NULL(1);

--- a/libjcat/jcat-self-test.c
+++ b/libjcat/jcat-self-test.c
@@ -523,7 +523,7 @@ jcat_pkcs7_engine_func(void)
 	g_assert_null(result_fail);
 	g_clear_error(&error);
 #else
-	g_test_skip("no GnuTLS support enabled");
+	g_test_skip("no PKCS7 support enabled");
 #endif
 }
 
@@ -577,7 +577,7 @@ jcat_pkcs7_engine_self_signed_func(void)
 	g_print("%s", str);
 	g_assert_cmpstr(str, ==, str_perfect);
 #else
-	g_test_skip("no GnuTLS support enabled");
+	g_test_skip("no PKCS7 support enabled");
 #endif
 }
 
@@ -635,7 +635,7 @@ jcat_ed25519_engine_func(void)
 	g_assert_null(result_fail);
 	g_clear_error(&error);
 #else
-	g_test_skip("no GnuTLS support enabled");
+	g_test_skip("no ED25519 support enabled");
 #endif
 }
 
@@ -701,7 +701,7 @@ jcat_ed25519_engine_self_signed_func(void)
 		g_assert_cmpstr(str, ==, str_perfect);
 	}
 #else
-	g_test_skip("no GnuTLS support enabled");
+	g_test_skip("no ED25519 support enabled");
 #endif
 }
 
@@ -780,7 +780,7 @@ jcat_context_verify_blob_func(void)
 	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED);
 	g_assert_null(result_disallow);
 #else
-	g_test_skip("no GnuTLS support enabled");
+	g_test_skip("no PKCS7 support enabled");
 #endif
 }
 
@@ -866,7 +866,7 @@ jcat_context_verify_item_sign_func(void)
 	g_assert_null(results_fail);
 	g_clear_error(&error);
 #else
-	g_test_skip("no GnuTLS support enabled");
+	g_test_skip("no PKCS7 support enabled");
 #endif
 }
 
@@ -936,7 +936,7 @@ jcat_context_verify_item_target_func(void)
 	g_assert_cmpint(jcat_result_get_timestamp(result), >=, 1502871248);
 	g_assert_cmpstr(jcat_result_get_authority(result), ==, "O=Hughski Limited");
 #else
-	g_test_skip("no GnuTLS support enabled");
+	g_test_skip("no PKCS7 support enabled");
 #endif
 }
 
@@ -1016,7 +1016,7 @@ jcat_context_verify_item_csum_func(void)
 	g_assert_null(results_fail);
 	g_clear_error(&error);
 #else
-	g_test_skip("no GnuTLS support enabled");
+	g_test_skip("no PKCS7 support enabled");
 #endif
 }
 

--- a/libjcat/meson.build
+++ b/libjcat/meson.build
@@ -33,8 +33,10 @@ if get_option('gpg')
   jcat_src += 'jcat-gpg-engine.c'
 endif
 if get_option('pkcs7')
-  jcat_src += 'jcat-pkcs7-common.c'
-  jcat_src += 'jcat-pkcs7-engine.c'
+  #jcat_src += 'jcat-pkcs7-common.c'
+  #jcat_src += 'jcat-pkcs7-engine.c'
+  jcat_src += 'jcat-pkcs7-crypto-common.c'
+  jcat_src += 'jcat-pkcs7-crypto-engine.c'
 endif
 if get_option('ed25519')
   jcat_src += 'jcat-ed25519-engine.c'

--- a/meson.build
+++ b/meson.build
@@ -137,9 +137,11 @@ libjcat_deps = [
 ]
 
 if get_option('pkcs7')
-  gnutls = dependency('gnutls', version : '>= 3.6.0')
+  libcrypto = dependency('libcrypto')
+  libjcat_deps += libcrypto
+  #gnutls = dependency('gnutls', version : '>= 3.6.0')
   conf.set('ENABLE_PKCS7', '1')
-  libjcat_deps += gnutls
+  #libjcat_deps += gnutls
 endif
 
 if get_option('ed25519')


### PR DESCRIPTION
Here's a PKCS7 backend using OpenSSL.

I tried to match the behaviour of the GnuTLS backend as much as I could.

OpenSSL provides separate set of PKCS7 and CMS functions, I chose to use the CMS ones. As a result the output signatures have `-----BEGIN CMS-----` as their header.

This still needs more work:

- [ ] I need to make sure the error messages make sense
- [ ] I'm unsure that the self signing is skipping verification checks.
- [ ] Setup meson to build either the GnuTLS or OpenSSL one
