### PR TITLE
jcat-self-test: Make the self-sign payload json

### DIFF
--- a/libjcat/jcat-self-test.c
+++ b/libjcat/jcat-self-test.c
@@ -531,7 +531,7 @@ static void
 jcat_pkcs7_engine_self_signed_func(void)
 {
 #ifdef HAVE_PKCS7
-	static const char payload_str[] = "Hello, world!";
+	static const char payload_str[] = "{\n  \"hello\": \"world\"\n}";
 	g_autofree gchar *str = NULL;
 	g_autoptr(JcatBlob) signature = NULL;
 	g_autoptr(JcatContext) context = jcat_context_new();
@@ -643,7 +643,7 @@ static void
 jcat_ed25519_engine_self_signed_func(void)
 {
 #ifdef HAVE_ED25519
-	static const char payload_str[] = "Hello, world!";
+	static const char payload_str[] = "{\n  \"hello\": \"world\"\n}";
 	g_autofree gchar *tmp_dir = NULL;
 	g_autoptr(JcatContext) context = jcat_context_new();
 	g_autoptr(JcatEngine) engine = NULL;


### PR DESCRIPTION
The CMS specification adds a content type ID for ASCII with CRLF line breaks.

The OpenSSL pkcs7 backend I've been working on requires a flag to specify that the content should be interpreted as binary.

The self test was passing without the binary flag being set for the signing operation.

By making the test payload json it is more likely to show similar issues.