### PR TITLE
trivial: Include jcat-gnutls-common.c when compiling ed25519

### DIFF
--- a/libjcat/meson.build
+++ b/libjcat/meson.build
@@ -37,6 +37,7 @@ if get_option('gnutls_pkcs7')
   jcat_src += 'jcat-gnutls-pkcs7-engine.c'
 endif
 if get_option('gnutls_ed25519')
+  jcat_src += 'jcat-gnutls-common.c'
   jcat_src += 'jcat-gnutls-ed25519-engine.c'
 endif
 


### PR DESCRIPTION
Currently the build fails if you configure it with `-Dgnutls_ed25519=true -Dgnutls_pkcs7=false`.